### PR TITLE
Feat: 권한 기반 주문 조회 기능 구현

### DIFF
--- a/src/main/java/com/chone/server/domains/order/controller/OrderController.java
+++ b/src/main/java/com/chone/server/domains/order/controller/OrderController.java
@@ -3,13 +3,21 @@ package com.chone.server.domains.order.controller;
 import com.chone.server.commons.util.UriGeneratorUtil;
 import com.chone.server.domains.auth.dto.CustomUserDetails;
 import com.chone.server.domains.order.dto.request.CreateOrderRequest;
+import com.chone.server.domains.order.dto.request.OrderFilterParams;
 import com.chone.server.domains.order.dto.response.CreateOrderResponse;
+import com.chone.server.domains.order.dto.response.OrderPageResponse;
+import com.chone.server.domains.order.dto.response.PageResponse;
 import com.chone.server.domains.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +37,17 @@ public class OrderController {
     CreateOrderResponse responseDto = service.createOrder(requestDto, principal);
 
     return ResponseEntity.created(UriGeneratorUtil.generateUri("")).body(responseDto);
+  }
+
+  @GetMapping
+  public ResponseEntity<PageResponse<OrderPageResponse>> getOrders(
+      @AuthenticationPrincipal CustomUserDetails principal,
+      @ModelAttribute("filterParams") OrderFilterParams filterParams,
+      @PageableDefault(page = 0, size = 10, sort = "createdat", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+    PageResponse<OrderPageResponse> responseDto =
+        service.getOrders(principal, filterParams, pageable);
+
+    return ResponseEntity.ok().body(responseDto);
   }
 }

--- a/src/main/java/com/chone/server/domains/order/domain/OrderStatus.java
+++ b/src/main/java/com/chone/server/domains/order/domain/OrderStatus.java
@@ -1,12 +1,19 @@
 package com.chone.server.domains.order.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum OrderStatus {
-  PENDING,
-  ACCEPTED,
-  FOOD_PREPARING,
-  FOOD_PREPARED,
-  AWAITING_DELIVERY,
-  IN_DELIVERY,
-  COMPLETED,
-  CANCELED
+  PENDING("주문 접수"),
+  ACCEPTED("주문 수락"),
+  FOOD_PREPARING("음식 준비 중"),
+  FOOD_PREPARED("음식 준비 완료"),
+  AWAITING_DELIVERY("배달 접수 중"),
+  IN_DELIVERY("배달 중"),
+  COMPLETED("주문 작업 및 픽업 완료"),
+  CANCELED("주문 취소");
+
+  private final String description;
 }

--- a/src/main/java/com/chone/server/domains/order/domain/OrderType.java
+++ b/src/main/java/com/chone/server/domains/order/domain/OrderType.java
@@ -1,6 +1,13 @@
 package com.chone.server.domains.order.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum OrderType {
-  ONLINE,
-  OFFLINE
+  ONLINE("배달"),
+  OFFLINE("대면");
+
+  private final String description;
 }

--- a/src/main/java/com/chone/server/domains/order/dto/request/OrderFilterParams.java
+++ b/src/main/java/com/chone/server/domains/order/dto/request/OrderFilterParams.java
@@ -1,0 +1,16 @@
+package com.chone.server.domains.order.dto.request;
+
+import com.chone.server.domains.order.domain.OrderStatus;
+import com.chone.server.domains.order.domain.OrderType;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record OrderFilterParams(
+    LocalDate startDate,
+    LocalDate endDate,
+    UUID storeId,
+    Long customerId,
+    OrderStatus status,
+    OrderType orderType,
+    Integer minPrice,
+    Integer maxPrice) {}

--- a/src/main/java/com/chone/server/domains/order/dto/response/CreateOrderResponse.java
+++ b/src/main/java/com/chone/server/domains/order/dto/response/CreateOrderResponse.java
@@ -1,16 +1,40 @@
 package com.chone.server.domains.order.dto.response;
 
 import com.chone.server.domains.order.domain.Order;
-import com.chone.server.domains.order.domain.OrderStatus;
+import com.chone.server.domains.order.domain.OrderItem;
+import com.chone.server.domains.store.domain.Store;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
-public record CreateOrderResponse(UUID orderId, OrderStatus status, LocalDateTime createdAt) {
-  private CreateOrderResponse(Order order) {
-    this(order.getId(), order.getStatus(), order.getCreatedAt());
+public record CreateOrderResponse(
+    OrderResponse order, StoreResponse store, List<OrderItemResponse> orderItem) {
+
+  private CreateOrderResponse(Order order, Store store, List<OrderItem> orderItems) {
+    this(
+        new OrderResponse(
+            order.getId(),
+            order.getTotalPrice().intValue(),
+            order.getOrderType().getDescription(),
+            order.getStatus().getDescription(),
+            order.getCreatedAt()),
+        new StoreResponse(store.getName(), store.getAddress()),
+        orderItems.stream()
+            .map(
+                orderItem ->
+                    new OrderItemResponse(orderItem.getProduct().getName(), orderItem.getAmount()))
+            .collect(Collectors.toList()));
   }
 
   public static CreateOrderResponse from(Order order) {
-    return new CreateOrderResponse(order);
+    return new CreateOrderResponse(order, order.getStore(), order.getOrderItems());
   }
+
+  private record OrderResponse(
+      UUID orderId, int totalPrice, String orderType, String status, LocalDateTime createdAt) {}
+
+  private record StoreResponse(String name, String address) {}
+
+  public record OrderItemResponse(String name, int amount) {}
 }

--- a/src/main/java/com/chone/server/domains/order/dto/response/OrderPageResponse.java
+++ b/src/main/java/com/chone/server/domains/order/dto/response/OrderPageResponse.java
@@ -1,0 +1,20 @@
+package com.chone.server.domains.order.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderPageResponse(
+    UUID id,
+    UUID storeId,
+    String storeName,
+    String type,
+    String status,
+    BigDecimal totalPrice,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt) {
+
+  @QueryProjection
+  public OrderPageResponse {}
+}

--- a/src/main/java/com/chone/server/domains/order/dto/response/PageResponse.java
+++ b/src/main/java/com/chone/server/domains/order/dto/response/PageResponse.java
@@ -1,0 +1,24 @@
+package com.chone.server.domains.order.dto.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(List<T> content, PageContent pageInfo) {
+  private PageResponse(Page<T> page) {
+    this(
+        page.getContent(),
+        new PageContent(
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.isLast()));
+  }
+
+  public static PageResponse from(Page page) {
+    return new PageResponse(page);
+  }
+
+  private record PageContent(
+      int page, int size, long totalElements, int totalPages, boolean last) {}
+}

--- a/src/main/java/com/chone/server/domains/order/exception/OrderExceptionCode.java
+++ b/src/main/java/com/chone/server/domains/order/exception/OrderExceptionCode.java
@@ -22,7 +22,7 @@ public enum OrderExceptionCode implements ExceptionCode {
   ORDER_STORE_CLOSED(SERVICE_UNAVAILABLE, "현재 가게가 영업 중이 아닙니다."),
   ORDER_PRODUCT_MISMATCH(BAD_REQUEST, "주문한 상품이 존재하지 않거나 일부 상품이 누락되었습니다."),
   ORDER_PRODUCT_UNAVAILABLE(BAD_REQUEST, "주문할 수 없는 상품입니다."),
-  ;
+  ORDER_FILTERING_ACCESS_DENIED(FORBIDDEN, "사용자 또는 가게별 주문 조회 권한이 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/chone/server/domains/order/exception/OrderExceptionCode.java
+++ b/src/main/java/com/chone/server/domains/order/exception/OrderExceptionCode.java
@@ -22,7 +22,8 @@ public enum OrderExceptionCode implements ExceptionCode {
   ORDER_STORE_CLOSED(SERVICE_UNAVAILABLE, "현재 가게가 영업 중이 아닙니다."),
   ORDER_PRODUCT_MISMATCH(BAD_REQUEST, "주문한 상품이 존재하지 않거나 일부 상품이 누락되었습니다."),
   ORDER_PRODUCT_UNAVAILABLE(BAD_REQUEST, "주문할 수 없는 상품입니다."),
-  ORDER_FILTERING_ACCESS_DENIED(FORBIDDEN, "사용자 또는 가게별 주문 조회 권한이 없습니다.");
+  ORDER_FILTERING_ACCESS_DENIED(FORBIDDEN, "사용자 또는 가게별 주문 조회 권한이 없습니다."),
+  STORE_ORDER_FILTERING_ACCESS_DENIED(FORBIDDEN, "가게별 주문 조회 권한이 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderRepositoryImpl.java
@@ -2,16 +2,23 @@ package com.chone.server.domains.order.infrastructure.jpa;
 
 import com.chone.server.commons.exception.ApiBusinessException;
 import com.chone.server.domains.order.domain.Order;
+import com.chone.server.domains.order.dto.request.OrderFilterParams;
+import com.chone.server.domains.order.dto.response.OrderPageResponse;
 import com.chone.server.domains.order.exception.OrderExceptionCode;
 import com.chone.server.domains.order.repository.OrderRepository;
+import com.chone.server.domains.order.repository.OrderSearchRepository;
+import com.chone.server.domains.user.domain.User;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class OrderRepositoryImpl implements OrderRepository {
   private final OrderJpaRepository jpaRepository;
+  private final OrderSearchRepository jpaSearchRepository;
 
   @Override
   public Order save(Order order) {
@@ -23,5 +30,23 @@ public class OrderRepositoryImpl implements OrderRepository {
     return jpaRepository
         .findById(uuid)
         .orElseThrow(() -> new ApiBusinessException(OrderExceptionCode.NOT_FOUND_ORDER));
+  }
+
+  @Override
+  public Page<OrderPageResponse> findOrdersByCustomer(
+      User customer, OrderFilterParams filterParams, Pageable pageable) {
+    return jpaSearchRepository.findOrdersByCustomer(customer, filterParams, pageable);
+  }
+
+  @Override
+  public Page<OrderPageResponse> findOrdersByOwner(
+      User owner, OrderFilterParams filterParams, Pageable pageable) {
+    return jpaSearchRepository.findOrdersByOwner(owner, filterParams, pageable);
+  }
+
+  @Override
+  public Page<OrderPageResponse> findOrdersByAdmin(
+      User admin, OrderFilterParams filterParams, Pageable pageable) {
+    return jpaSearchRepository.findOrdersByAdmin(admin, filterParams, pageable);
   }
 }

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.chone.server.domains.order.infrastructure.jpa;
 
+import static com.chone.server.domains.order.domain.QOrder.order;
+
 import com.chone.server.commons.exception.ApiBusinessException;
 import com.chone.server.domains.order.dto.request.OrderFilterParams;
 import com.chone.server.domains.order.dto.response.OrderPageResponse;
@@ -49,7 +51,11 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
     }
   }
 
-  private void addCustomerCondition(List<BooleanExpression> conditions, User customer) {}
+  private void addCustomerCondition(List<BooleanExpression> conditions, User customer) {
+    if (customer != null) {
+      conditions.add(order.user.eq(customer));
+    }
+  }
 
   private Page<OrderPageResponse> getOrders(
       List<BooleanExpression> conditions, OrderFilterParams filterParams, Pageable pageable) {

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -87,7 +87,11 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
     }
   }
 
-  private void addStoresByOwnerCondition(List<BooleanExpression> conditions, User owner) {}
+  private void addStoresByOwnerCondition(List<BooleanExpression> conditions, User owner) {
+    if (owner != null) {
+      conditions.add(order.store.user.eq(owner));
+    }
+  }
 
   private Page<OrderPageResponse> getOrders(
       List<BooleanExpression> conditions, OrderFilterParams filterParams, Pageable pageable) {

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -153,7 +153,9 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
   }
 
   private BooleanExpression buildWhereCondition(List<BooleanExpression> conditions) {
-    return null;
+    return conditions.isEmpty()
+        ? null
+        : conditions.stream().reduce(BooleanExpression::and).orElse(null);
   }
 
   private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -75,7 +75,11 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
     }
   }
 
-  private void validateNoStoreFiltering(UUID uuid) {}
+  private void validateNoStoreFiltering(UUID storeId) {
+    if (storeId != null) {
+      throw new ApiBusinessException(OrderExceptionCode.STORE_ORDER_FILTERING_ACCESS_DENIED);
+    }
+  }
 
   private void addCustomerCondition(List<BooleanExpression> conditions, User customer) {
     if (customer != null) {

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.chone.server.domains.order.infrastructure.jpa;
 
+import com.chone.server.commons.exception.ApiBusinessException;
 import com.chone.server.domains.order.dto.request.OrderFilterParams;
 import com.chone.server.domains.order.dto.response.OrderPageResponse;
+import com.chone.server.domains.order.exception.OrderExceptionCode;
 import com.chone.server.domains.order.repository.OrderSearchRepository;
 import com.chone.server.domains.user.domain.User;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -41,7 +43,11 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
     return null;
   }
 
-  private void validateNoUnauthorizedFiltering(OrderFilterParams filterParams) {}
+  private void validateNoUnauthorizedFiltering(OrderFilterParams filterParams) {
+    if (filterParams.storeId() != null || filterParams.customerId() != null) {
+      throw new ApiBusinessException(OrderExceptionCode.ORDER_FILTERING_ACCESS_DENIED);
+    }
+  }
 
   private void addCustomerCondition(List<BooleanExpression> conditions, User customer) {}
 

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -3,19 +3,26 @@ package com.chone.server.domains.order.infrastructure.jpa;
 import static com.chone.server.domains.order.domain.QOrder.order;
 
 import com.chone.server.commons.exception.ApiBusinessException;
+import com.chone.server.domains.order.domain.OrderStatus;
+import com.chone.server.domains.order.domain.OrderType;
 import com.chone.server.domains.order.dto.request.OrderFilterParams;
 import com.chone.server.domains.order.dto.response.OrderPageResponse;
+import com.chone.server.domains.order.dto.response.QOrderPageResponse;
 import com.chone.server.domains.order.exception.OrderExceptionCode;
 import com.chone.server.domains.order.repository.OrderSearchRepository;
 import com.chone.server.domains.user.domain.User;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @Slf4j
@@ -59,6 +66,55 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
 
   private Page<OrderPageResponse> getOrders(
       List<BooleanExpression> conditions, OrderFilterParams filterParams, Pageable pageable) {
+
+    addStatusCondition(conditions, filterParams.status());
+    addOrderTypeCondition(conditions, filterParams.orderType());
+    addPriceCondition(conditions, filterParams.minPrice(), filterParams.maxPrice());
+    addDateCondition(conditions, filterParams.startDate(), filterParams.endDate());
+
+    BooleanExpression whereCondition = buildWhereCondition(conditions);
+
+    List<OrderPageResponse> content =
+        queryFactory
+            .select(
+                new QOrderPageResponse(
+                    order.id,
+                    order.store.id,
+                    order.store.name,
+                    order.orderType.stringValue(),
+                    order.status.stringValue(),
+                    order.totalPrice,
+                    order.createdAt,
+                    order.updatedAt))
+            .from(order)
+            .join(order.store)
+            .where(whereCondition)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(getOrderSpecifier(pageable))
+            .fetch();
+
+    JPAQuery<Long> countQuery =
+        queryFactory.select(order.count()).from(order).join(order.store).where(whereCondition);
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+  }
+
+  private void addStatusCondition(List<BooleanExpression> conditions, OrderStatus status) {}
+
+  private void addOrderTypeCondition(List<BooleanExpression> conditions, OrderType orderType) {}
+
+  private void addPriceCondition(
+      List<BooleanExpression> conditions, Integer integer, Integer integer1) {}
+
+  private void addDateCondition(
+      List<BooleanExpression> conditions, LocalDate localDate, LocalDate localDate1) {}
+
+  private BooleanExpression buildWhereCondition(List<BooleanExpression> conditions) {
+    return null;
+  }
+
+  private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
     return null;
   }
 }

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.chone.server.domains.order.infrastructure.jpa;
+
+import com.chone.server.domains.order.dto.request.OrderFilterParams;
+import com.chone.server.domains.order.dto.response.OrderPageResponse;
+import com.chone.server.domains.order.repository.OrderSearchRepository;
+import com.chone.server.domains.user.domain.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class OrderSearchRepositoryImpl implements OrderSearchRepository {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<OrderPageResponse> findOrdersByCustomer(
+      User customer, OrderFilterParams filterParams, Pageable pageable) {
+    return null;
+  }
+
+  @Override
+  public Page<OrderPageResponse> findOrdersByOwner(
+      User owner, OrderFilterParams filterParams, Pageable pageable) {
+    return null;
+  }
+
+  @Override
+  public Page<OrderPageResponse> findOrdersByAdmin(
+      User admin, OrderFilterParams filterParams, Pageable pageable) {
+    return null;
+  }
+}

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -66,7 +66,14 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
   @Override
   public Page<OrderPageResponse> findOrdersByAdmin(
       User admin, OrderFilterParams filterParams, Pageable pageable) {
-    return null;
+    List<BooleanExpression> conditions = new ArrayList<>();
+    if (filterParams.storeId() != null) {
+      addStoreIdCondition(conditions, filterParams.storeId());
+    }
+    if (filterParams.customerId() != null) {
+      addCustomerIdCondition(conditions, filterParams.customerId());
+    }
+    return getOrders(conditions, filterParams, pageable);
   }
 
   private void validateNoUnauthorizedFiltering(OrderFilterParams filterParams) {
@@ -92,6 +99,10 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
       conditions.add(order.store.user.eq(owner));
     }
   }
+
+  private void addStoreIdCondition(List<BooleanExpression> conditions, UUID uuid) {}
+
+  private void addCustomerIdCondition(List<BooleanExpression> conditions, Long aLong) {}
 
   private Page<OrderPageResponse> getOrders(
       List<BooleanExpression> conditions, OrderFilterParams filterParams, Pageable pageable) {

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -4,7 +4,10 @@ import com.chone.server.domains.order.dto.request.OrderFilterParams;
 import com.chone.server.domains.order.dto.response.OrderPageResponse;
 import com.chone.server.domains.order.repository.OrderSearchRepository;
 import com.chone.server.domains.user.domain.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -20,7 +23,10 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
   @Override
   public Page<OrderPageResponse> findOrdersByCustomer(
       User customer, OrderFilterParams filterParams, Pageable pageable) {
-    return null;
+    validateNoUnauthorizedFiltering(filterParams);
+    List<BooleanExpression> conditions = new ArrayList<>();
+    addCustomerCondition(conditions, customer);
+    return getOrders(conditions, filterParams, pageable);
   }
 
   @Override
@@ -32,6 +38,15 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
   @Override
   public Page<OrderPageResponse> findOrdersByAdmin(
       User admin, OrderFilterParams filterParams, Pageable pageable) {
+    return null;
+  }
+
+  private void validateNoUnauthorizedFiltering(OrderFilterParams filterParams) {}
+
+  private void addCustomerCondition(List<BooleanExpression> conditions, User customer) {}
+
+  private Page<OrderPageResponse> getOrders(
+      List<BooleanExpression> conditions, OrderFilterParams filterParams, Pageable pageable) {
     return null;
   }
 }

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -100,9 +100,17 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
     }
   }
 
-  private void addStoreIdCondition(List<BooleanExpression> conditions, UUID uuid) {}
+  private void addStoreIdCondition(List<BooleanExpression> conditions, UUID storeId) {
+    if (storeId != null) {
+      conditions.add(order.store.id.eq(storeId));
+    }
+  }
 
-  private void addCustomerIdCondition(List<BooleanExpression> conditions, Long aLong) {}
+  private void addCustomerIdCondition(List<BooleanExpression> conditions, Long customerId) {
+    if (customerId != null) {
+      conditions.add(order.user.id.eq(customerId));
+    }
+  }
 
   private Page<OrderPageResponse> getOrders(
       List<BooleanExpression> conditions, OrderFilterParams filterParams, Pageable pageable) {

--- a/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/order/infrastructure/jpa/OrderSearchRepositoryImpl.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -54,7 +55,12 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
   @Override
   public Page<OrderPageResponse> findOrdersByOwner(
       User owner, OrderFilterParams filterParams, Pageable pageable) {
-    return null;
+    validateNoStoreFiltering(filterParams.storeId());
+
+    List<BooleanExpression> conditions = new ArrayList<>();
+    addStoresByOwnerCondition(conditions, owner);
+
+    return getOrders(conditions, filterParams, pageable);
   }
 
   @Override
@@ -69,11 +75,15 @@ public class OrderSearchRepositoryImpl implements OrderSearchRepository {
     }
   }
 
+  private void validateNoStoreFiltering(UUID uuid) {}
+
   private void addCustomerCondition(List<BooleanExpression> conditions, User customer) {
     if (customer != null) {
       conditions.add(order.user.eq(customer));
     }
   }
+
+  private void addStoresByOwnerCondition(List<BooleanExpression> conditions, User owner) {}
 
   private Page<OrderPageResponse> getOrders(
       List<BooleanExpression> conditions, OrderFilterParams filterParams, Pageable pageable) {

--- a/src/main/java/com/chone/server/domains/order/repository/OrderSearchRepository.java
+++ b/src/main/java/com/chone/server/domains/order/repository/OrderSearchRepository.java
@@ -1,18 +1,12 @@
 package com.chone.server.domains.order.repository;
 
-import com.chone.server.domains.order.domain.Order;
 import com.chone.server.domains.order.dto.request.OrderFilterParams;
 import com.chone.server.domains.order.dto.response.OrderPageResponse;
 import com.chone.server.domains.user.domain.User;
-import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface OrderRepository {
-  Order save(Order order);
-
-  Order findById(UUID uuid);
-
+public interface OrderSearchRepository {
   Page<OrderPageResponse> findOrdersByCustomer(
       User customer, OrderFilterParams filterParams, Pageable pageable);
 

--- a/src/main/java/com/chone/server/domains/order/service/OrderDomainService.java
+++ b/src/main/java/com/chone/server/domains/order/service/OrderDomainService.java
@@ -72,7 +72,7 @@ public class OrderDomainService {
   }
 
   private void validateStoreOperationStatus(Store store) {
-    if (!store.isOpen()) {
+    if (!store.getIsOpen()) {
       throw new ApiBusinessException(OrderExceptionCode.ORDER_STORE_CLOSED);
     }
   }

--- a/src/main/java/com/chone/server/domains/order/service/OrderService.java
+++ b/src/main/java/com/chone/server/domains/order/service/OrderService.java
@@ -5,16 +5,22 @@ import com.chone.server.domains.order.domain.Order;
 import com.chone.server.domains.order.domain.OrderType;
 import com.chone.server.domains.order.dto.request.CreateOrderRequest;
 import com.chone.server.domains.order.dto.request.CreateOrderRequest.OrderItemRequest;
+import com.chone.server.domains.order.dto.request.OrderFilterParams;
 import com.chone.server.domains.order.dto.response.CreateOrderResponse;
+import com.chone.server.domains.order.dto.response.OrderPageResponse;
+import com.chone.server.domains.order.dto.response.PageResponse;
 import com.chone.server.domains.order.repository.OrderRepository;
 import com.chone.server.domains.product.domain.Product;
 import com.chone.server.domains.product.service.ProductService;
 import com.chone.server.domains.store.domain.Store;
 import com.chone.server.domains.store.service.StoreService;
+import com.chone.server.domains.user.domain.Role;
 import com.chone.server.domains.user.domain.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,5 +56,23 @@ public class OrderService {
     //       2. 배달
 
     return CreateOrderResponse.from(savedOrder);
+  }
+
+  public PageResponse<OrderPageResponse> getOrders(
+      CustomUserDetails principal, OrderFilterParams filterParams, Pageable pageable) {
+    User user = principal.getUser();
+
+    return PageResponse.from(findOrdersByRole(user, filterParams, pageable));
+  }
+
+  private Page<OrderPageResponse> findOrdersByRole(
+      User user, OrderFilterParams filterParams, Pageable pageable) {
+    Role role = user.getRole();
+
+    return switch (role) {
+      case CUSTOMER -> repository.findOrdersByCustomer(user, filterParams, pageable);
+      case OWNER -> repository.findOrdersByOwner(user, filterParams, pageable);
+      case MANAGER, MASTER -> repository.findOrdersByAdmin(user, filterParams, pageable);
+    };
   }
 }


### PR DESCRIPTION
## 📢 개요
QueryDsl 기능을 활용하여 사용자 역할(고객, 점주, 관리자)에 따라 적절한 권한으로 주문을 조회할 수 있는 기능을 구현했습니다. 

### API 스펙
| 항목 | 내용 |
|------|------|
| 메서드 | **`GET`** |
| 경로 | `/api/v1/orders` |
| 권한 | 모든 역할 접근 가능 (역할별 조회 범위 제한) |
| 파라미터 | `OrderFilterParams` (필터링 옵션) |
| 페이지네이션 | page, size, sort 지원 (기본값: page=0, size=10, sort=createdat,desc) |
| 응답 | 200 OK + `PageResponse<OrderPageResponse>` |

### 역할별 접근 제어
| 역할 | 조회 가능 범위 | 필터링 제한 |
|------|--------------|------------|
| `CUSTOMER` | 자신의 주문만 조회 | storeId, customerId 필터링 불가 |
| `OWNER` | 자신의 매장 주문만 조회 | customerId 필터링 가능 |
| `MANAGER`, `MASTER` | 모든 주문 조회 | 모든 필터링 가능 |

### 필터링 옵션
| 필드 | 타입 | 설명 |
|------|------|------|
| startDate | LocalDate | 조회 시작일 |
| endDate | LocalDate | 조회 종료일 |
| storeId | UUID | 매장 ID |
| customerId | Long | 고객 ID |
| status | OrderStatus | 주문 상태 |
| orderType | OrderType | 주문 유형 |
| minPrice | Integer | 최소 가격 |
| maxPrice | Integer | 최대 가격 |

<br/>

## 📝 작업 내용
### 변경 사항
1. **DTO 클래스 구현**
   - `OrderFilterParams`: 주문 필터링 파라미터 (날짜 범위, 가게 아이디, 고객 유저 아이디, 주문 상태, 주문유형, 가격 범위)
   - `OrderPageResponse`: 주문 목록 조회 결과를 위한 응답 클래스
   - `PageResponse`: 페이지네이션 정보를 포함한 응답 데이터 구조

2. **Controller 계층**
   - `GET /orders` 엔드포인트 구현
   - 인증된 사용자 정보 활용
   - 페이지네이션 및 정렬 지원

3. **Service 계층**
   - `getOrders` 메서드 구현 
   - 사용자 역할에 따른 조회 전략 분기 처리

4. **Repository 계층 구조화**
   - `OrderRepository`: 기본 CRUD와 조회 메서드를 포함한 고수준 인터페이스
   - `OrderSearchRepository`: 복잡한 조회 쿼리 전용 인터페이스
   - `OrderSearchRepositoryImpl`: QueryDSL을 활용한 구현체
   - `OrderRepositoryImpl`: JPA Repository와 Search Repository 위임 패턴 적용

5. **역할별 조회 로직 구현**
   - `findOrdersByCustomer`: 고객은 자신의 주문만 조회 가능
   - `findOrdersByOwner`: 점주는 자신의 매장 주문만 조회 가능
   - `findOrdersByAdmin`: 관리자/마스터는 모든 주문 조회 가능

6. **동적 필터링 구현**
   - 상태(OrderStatus) 필터링
   - 주문 유형(OrderType) 필터링
   - 가격 범위 필터링 (최소/최대)
   - 날짜 범위 필터링 (시작일/종료일)
   - 동적 정렬 (가격, 생성일, 수정일 기준)

### 추가 설명
#### 필터링 조건 상세
1. **날짜 필터링**
   - 시작일/종료일 단일 또는 범위 지정 가능
   - 시작일: 해당일 00:00:00부터
   - 종료일: 해당일 23:59:59.999999999까지

2. **가격 필터링**
   - 최소/최대 가격 단일 또는 범위 지정 가능
   - NumberFormatException 예외 처리 포함

3. **정렬 기능**
   - 지원 필드: totalprice, createdat, updatedat
   - 기본 정렬: createdat DESC
   - 여러 정렬 조건 조합 가능

#### 권한별 조회 제약
1. **`CUSTOMER`**
   - storeId, customerId로 필터링 시도 시 `ORDER_FILTERING_ACCESS_DENIED` 예외 발생
   - 자신의 주문만 조회 가능 (order.user.eq(customer))

2. **`OWNER`**
   - 자신이 소유한 매장의 주문만 조회 가능 (order.store.user.eq(owner))
   - 다른 가게 필터링 시도 시 `STORE_ORDER_FILTERING_ACCESS_DENIED` 예외 발생
   - 선택적으로 customerId 필터링 가능

3. **`MANAGER/MASTER`**
   - 모든 주문에 접근 가능
   - 선택적으로 storeId, customerId 필터링 가능

#### 예시
![image](https://github.com/user-attachments/assets/6f34b40e-9ec5-42fc-8af4-73594c5bb380)


<br/>



## 💬 리뷰 요구사항
1. 각 역할별 접근 제어 로직이 적절한지 검토 부탁드립니다.

<br/>



#### #️⃣ 연관된 이슈
closed #32 

<br/>



## 📃 PR 유형
이 PR은 어떤 변경 사항을 포함하고 있나요?
- [x] 새로운 기능 추가

## ✅ Check List
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] CI/CD 파이프라인을 통과했습니다.