### PR TITLE
Feat: 리뷰 목록, 상세 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/chone/server/domains/order/service/OrderDomainService.java
+++ b/src/main/java/com/chone/server/domains/order/service/OrderDomainService.java
@@ -96,7 +96,7 @@ public class OrderDomainService {
   }
 
   private void validateProduct(Product product) {
-    if (!product.isAvailable()) {
+    if (!product.getIsAvailable()) {
       throw new ApiBusinessException(OrderExceptionCode.ORDER_PRODUCT_UNAVAILABLE);
     }
   }

--- a/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
+++ b/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
@@ -3,10 +3,12 @@ package com.chone.server.domains.review.controller;
 import com.chone.server.domains.auth.dto.CustomUserDetails;
 import com.chone.server.domains.review.dto.request.CreateRequestDto;
 import com.chone.server.domains.review.dto.request.ReviewListRequestDto;
+import com.chone.server.domains.review.dto.response.ReviewDetailResponseDto;
 import com.chone.server.domains.review.dto.response.ReviewListResponseDto;
 import com.chone.server.domains.review.dto.response.ReviewResponseDto;
 import com.chone.server.domains.review.service.ReviewService;
 import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -40,6 +42,14 @@ public class ReviewController {
     Pageable pageable = requestDto.toPageable();
 
     ReviewListResponseDto response = reviewService.getReviews(requestDto, principal, pageable);
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ReviewDetailResponseDto> getReview(
+      @PathVariable("id") UUID id, @AuthenticationPrincipal CustomUserDetails principal) {
+
+    ReviewDetailResponseDto response = reviewService.getReviewById(id, principal);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
+++ b/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
@@ -6,6 +6,7 @@ import com.chone.server.domains.review.dto.request.ReviewListRequestDto;
 import com.chone.server.domains.review.dto.response.ReviewListResponseDto;
 import com.chone.server.domains.review.dto.response.ReviewResponseDto;
 import com.chone.server.domains.review.service.ReviewService;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -33,10 +34,12 @@ public class ReviewController {
   @GetMapping
   public ResponseEntity<ReviewListResponseDto> getReviews(
       @AuthenticationPrincipal CustomUserDetails principal,
-      @ModelAttribute ReviewListRequestDto requestDTO,
-      Pageable pageable) {
+      @RequestParam Map<String, String> params) {
 
-    ReviewListResponseDto response = reviewService.getReviews(requestDTO, principal, pageable);
+    ReviewListRequestDto requestDto = ReviewListRequestDto.from(params);
+    Pageable pageable = requestDto.toPageable();
+
+    ReviewListResponseDto response = reviewService.getReviews(requestDto, principal, pageable);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
+++ b/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
@@ -1,10 +1,10 @@
 package com.chone.server.domains.review.controller;
 
 import com.chone.server.domains.auth.dto.CustomUserDetails;
-import com.chone.server.domains.review.dto.request.CreateRequestDTO;
-import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
+import com.chone.server.domains.review.dto.request.CreateRequestDto;
+import com.chone.server.domains.review.dto.request.ReviewListRequestDto;
 import com.chone.server.domains.review.dto.response.ReviewListResponseDto;
-import com.chone.server.domains.review.dto.response.ReviewResponseDTO;
+import com.chone.server.domains.review.dto.response.ReviewResponseDto;
 import com.chone.server.domains.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -22,10 +22,10 @@ public class ReviewController {
 
   @PreAuthorize("hasRole('CUSTOMER')")
   @PostMapping
-  public ResponseEntity<ReviewResponseDTO> createReview(
-      @AuthenticationPrincipal CustomUserDetails principal, @RequestBody CreateRequestDTO request) {
+  public ResponseEntity<ReviewResponseDto> createReview(
+      @AuthenticationPrincipal CustomUserDetails principal, @RequestBody CreateRequestDto request) {
 
-    ReviewResponseDTO response = reviewService.createReview(request, principal.getUser());
+    ReviewResponseDto response = reviewService.createReview(request, principal.getUser());
 
     return ResponseEntity.ok(response);
   }
@@ -33,7 +33,7 @@ public class ReviewController {
   @GetMapping
   public ResponseEntity<ReviewListResponseDto> getReviews(
       @AuthenticationPrincipal CustomUserDetails principal,
-      @ModelAttribute ReviewListRequestDTO requestDTO,
+      @ModelAttribute ReviewListRequestDto requestDTO,
       Pageable pageable) {
 
     ReviewListResponseDto response = reviewService.getReviews(requestDTO, principal, pageable);

--- a/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
+++ b/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
@@ -2,9 +2,12 @@ package com.chone.server.domains.review.controller;
 
 import com.chone.server.domains.auth.dto.CustomUserDetails;
 import com.chone.server.domains.review.dto.request.CreateRequestDTO;
+import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
+import com.chone.server.domains.review.dto.response.ReviewListResponseDto;
 import com.chone.server.domains.review.dto.response.ReviewResponseDTO;
 import com.chone.server.domains.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +27,16 @@ public class ReviewController {
 
     ReviewResponseDTO response = reviewService.createReview(request, principal.getUser());
 
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping
+  public ResponseEntity<ReviewListResponseDto> getReviews(
+      @AuthenticationPrincipal CustomUserDetails principal,
+      @ModelAttribute ReviewListRequestDTO requestDTO,
+      Pageable pageable) {
+
+    ReviewListResponseDto response = reviewService.getReviews(requestDTO, principal, pageable);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/chone/server/domains/review/dto/request/CreateRequestDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/request/CreateRequestDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 @NoArgsConstructor
-public class CreateRequestDTO {
+public class CreateRequestDto {
 
   private UUID orderId;
   private UUID storeId;

--- a/src/main/java/com/chone/server/domains/review/dto/request/ReviewListRequestDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/request/ReviewListRequestDto.java
@@ -1,0 +1,32 @@
+package com.chone.server.domains.review.dto.request;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class ReviewListRequestDto {
+
+  private Integer page = 0;
+  private Integer size = 10;
+  private String sort = "createAt";
+  private String direction = "desc";
+  private UUID storeId;
+  private Long customerId;
+  private UUID orderId;
+  private Integer minRating;
+  private Integer maxRating;
+  private Boolean hasImage;
+
+  @DateTimeFormat(pattern = "yyyy-MM-dd")
+  private String startDate;
+
+  @DateTimeFormat(pattern = "yyyy-MM-dd")
+  private String endDate;
+}

--- a/src/main/java/com/chone/server/domains/review/dto/request/ReviewListRequestDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/request/ReviewListRequestDto.java
@@ -1,10 +1,14 @@
 package com.chone.server.domains.review.dto.request;
 
+import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @AllArgsConstructor
@@ -13,15 +17,15 @@ import org.springframework.format.annotation.DateTimeFormat;
 @NoArgsConstructor
 public class ReviewListRequestDto {
 
-  private Integer page = 0;
-  private Integer size = 10;
-  private String sort = "createAt";
-  private String direction = "desc";
+  private Integer page;
+  private Integer size;
+  private String sort;
+  private String direction;
   private UUID storeId;
   private Long customerId;
   private UUID orderId;
-  private Integer minRating;
-  private Integer maxRating;
+  private Double minRating;
+  private Double maxRating;
   private Boolean hasImage;
 
   @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -29,4 +33,39 @@ public class ReviewListRequestDto {
 
   @DateTimeFormat(pattern = "yyyy-MM-dd")
   private String endDate;
+
+  public static ReviewListRequestDto from(Map<String, String> params) {
+    return ReviewListRequestDto.builder()
+        .page(params.containsKey("page") ? Integer.parseInt(params.get("page")) : 0)
+        .size(params.containsKey("size") ? Integer.parseInt(params.get("size")) : 10)
+        .sort(params.getOrDefault("sort", "createdAt"))
+        .direction(params.getOrDefault("direction", "desc"))
+        .storeId(params.containsKey("storeId") ? UUID.fromString(params.get("storeId")) : null)
+        .customerId(
+            params.containsKey("customerId") ? Long.parseLong(params.get("customerId")) : null)
+        .orderId(params.containsKey("orderId") ? UUID.fromString(params.get("orderId")) : null)
+        .minRating(
+            params.containsKey("minRating") ? Double.parseDouble(params.get("minRating")) : null)
+        .maxRating(
+            params.containsKey("maxRating") ? Double.parseDouble(params.get("maxRating")) : null)
+        .hasImage(
+            params.containsKey("hasImage") ? Boolean.parseBoolean(params.get("hasImage")) : null)
+        .startDate(params.get("startDate"))
+        .endDate(params.get("endDate"))
+        .build();
+  }
+
+  public Pageable toPageable() {
+
+    String[] sortParams = this.sort.split(",");
+
+    String sortField = sortParams[0];
+
+    String sortDirection = sortParams.length > 1 ? sortParams[1] : this.direction;
+
+    Sort.Direction direction =
+        "asc".equalsIgnoreCase(sortDirection) ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+    return PageRequest.of(this.page, this.size, Sort.by(direction, sortField));
+  }
 }

--- a/src/main/java/com/chone/server/domains/review/dto/response/PageInfoDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/response/PageInfoDto.java
@@ -1,0 +1,29 @@
+package com.chone.server.domains.review.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class PageInfoDto {
+
+  private int page;
+  private int size;
+  private long totalElements;
+  private int totalPages;
+
+  public static <T> PageInfoDto from(Page<T> page) {
+
+    return PageInfoDto.builder()
+        .page(page.getNumber())
+        .size(page.getSize())
+        .totalElements(page.getTotalElements())
+        .totalPages(page.getTotalPages())
+        .build();
+  }
+}

--- a/src/main/java/com/chone/server/domains/review/dto/response/ReviewDetailResponseDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/response/ReviewDetailResponseDto.java
@@ -1,0 +1,52 @@
+package com.chone.server.domains.review.dto.response;
+
+import com.chone.server.domains.review.domain.Review;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReviewDetailResponseDto {
+  private UUID reviewId;
+  private UUID orderId;
+  private StoreInfo storeInfo;
+  private CustomerInfo customerInfo;
+  private String content;
+  private BigDecimal rating;
+  private String imageUrl;
+  private LocalDateTime writtenAt;
+
+  public static ReviewDetailResponseDto from(Review review) {
+    return ReviewDetailResponseDto.builder()
+        .reviewId(review.getId())
+        .orderId(review.getOrder().getId())
+        .storeInfo(new StoreInfo(review.getStore().getId(), review.getStore().getName()))
+        .customerInfo(new CustomerInfo(review.getUser().getId(), review.getUser().getUsername()))
+        .content(review.getContent())
+        .rating(review.getRating())
+        .imageUrl(review.getImageUrl())
+        .writtenAt(review.getCreatedAt())
+        .build();
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class StoreInfo {
+    private UUID storeId;
+    private String storeName;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class CustomerInfo {
+    private Long customerId;
+    private String username;
+  }
+}

--- a/src/main/java/com/chone/server/domains/review/dto/response/ReviewListResponseDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/response/ReviewListResponseDto.java
@@ -1,0 +1,26 @@
+package com.chone.server.domains.review.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class ReviewListResponseDto {
+
+  private List<ReviewPageResponseDto> content;
+  private PageInfoDto pageInfo;
+
+  public static ReviewListResponseDto from(Page<ReviewPageResponseDto> page) {
+
+    return ReviewListResponseDto.builder()
+        .content(page.getContent())
+        .pageInfo(PageInfoDto.from(page))
+        .build();
+  }
+}

--- a/src/main/java/com/chone/server/domains/review/dto/response/ReviewPageResponseDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/response/ReviewPageResponseDto.java
@@ -1,0 +1,39 @@
+package com.chone.server.domains.review.dto.response;
+
+import com.chone.server.domains.review.domain.Review;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class ReviewPageResponseDto {
+
+  private UUID reviewId;
+  private UUID orderId;
+  private UUID storeId;
+  private Long customerId;
+  private String content;
+  private String imageUrl;
+  private Double rating;
+  private LocalDateTime writtenAt;
+
+  public static ReviewPageResponseDto from(Review review) {
+
+    return ReviewPageResponseDto.builder()
+        .reviewId(review.getId())
+        .orderId(review.getOrder().getId())
+        .storeId(review.getStore().getId())
+        .customerId(review.getUser().getId())
+        .content(review.getContent())
+        .imageUrl(review.getImageUrl())
+        .rating(review.getRating().doubleValue())
+        .writtenAt(review.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/chone/server/domains/review/dto/response/ReviewReadResponseDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/response/ReviewReadResponseDto.java
@@ -1,0 +1,40 @@
+package com.chone.server.domains.review.dto.response;
+
+import com.chone.server.domains.review.domain.Review;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+public class ReviewReadResponseDto {
+
+  private UUID reviewId;
+  private UUID orderId;
+  private UUID storeId;
+  private Long customerId;
+  private BigDecimal rating;
+  private String content;
+  private String imageUrl;
+  private LocalDateTime writtenAt;
+
+  public static ReviewReadResponseDto from(Review review) {
+
+    return ReviewReadResponseDto.builder()
+        .reviewId(review.getId())
+        .orderId(review.getOrder().getId())
+        .storeId(review.getStore().getId())
+        .customerId(review.getUser().getId())
+        .rating(review.getRating())
+        .content(review.getContent())
+        .imageUrl(review.getImageUrl())
+        .writtenAt(review.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/chone/server/domains/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/response/ReviewResponseDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 @NoArgsConstructor
-public class ReviewResponseDTO {
+public class ReviewResponseDto {
 
   private UUID reviewId;
   private LocalDateTime createdAt;

--- a/src/main/java/com/chone/server/domains/review/exception/ReviewExceptionCode.java
+++ b/src/main/java/com/chone/server/domains/review/exception/ReviewExceptionCode.java
@@ -18,7 +18,9 @@ public enum ReviewExceptionCode implements ExceptionCode {
   STORE_NOT_FOUND(NOT_FOUND, "해당 가게를 찾을 수 없습니다."),
   REVIEW_ALREADY_EXISTS(CONFLICT, "해당 주문에 대한 리뷰가 이미 존재합니다."),
   ORDER_NOT_COMPLETED(UNPROCESSABLE_ENTITY, "완료된 주문에 대해서만 리뷰를 작성할 수 있습니다."),
-  FILE_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "이미지 업로드 중 오류가 발생했습니다.");
+  FILE_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "이미지 업로드 중 오류가 발생했습니다."),
+  REVIEW_ACCESS_DENIED(FORBIDDEN, "해당 요청을 수행할 권한이 없습니다."),
+  REVIEW_NOT_FOUND(NOT_FOUND, "요청하신 리뷰 정보를 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
@@ -1,8 +1,8 @@
 package com.chone.server.domains.review.repository;
 
 import com.chone.server.domains.review.domain.QReview;
-import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
-import com.chone.server.domains.review.dto.response.ReviewPageResponseDTO;
+import com.chone.server.domains.review.dto.request.ReviewListRequestDto;
+import com.chone.server.domains.review.dto.response.ReviewPageResponseDto;
 import com.chone.server.domains.user.domain.User;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -20,8 +20,8 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public Page<ReviewPageResponseDTO> findReviewsByCustomer(
-      User customer, ReviewListRequestDTO filterParams, Pageable pageable) {
+  public Page<ReviewPageResponseDto> findReviewsByCustomer(
+      User customer, ReviewListRequestDto filterParams, Pageable pageable) {
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
 
@@ -33,8 +33,8 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   }
 
   @Override
-  public Page<ReviewPageResponseDTO> findReviewsByOwner(
-      User owner, ReviewListRequestDTO filterParams, Pageable pageable) {
+  public Page<ReviewPageResponseDto> findReviewsByOwner(
+      User owner, ReviewListRequestDto filterParams, Pageable pageable) {
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
 
@@ -46,8 +46,8 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   }
 
   @Override
-  public Page<ReviewPageResponseDTO> findReviewsByManagerOrMaster(
-      User user, ReviewListRequestDTO filterParams, Pageable pageable) { // ✅ User 인자 추가!
+  public Page<ReviewPageResponseDto> findReviewsByManagerOrMaster(
+      User user, ReviewListRequestDto filterParams, Pageable pageable) { // ✅ User 인자 추가!
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
 
@@ -57,7 +57,7 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   }
 
   private void applyFilters(
-      BooleanBuilder predicate, ReviewListRequestDTO filterParams, QReview review) {
+      BooleanBuilder predicate, ReviewListRequestDto filterParams, QReview review) {
     if (filterParams.getStoreId() != null) {
       predicate.and(review.store.id.eq(filterParams.getStoreId()));
     }
@@ -75,9 +75,9 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
     }
   }
 
-  private Page<ReviewPageResponseDTO> executeQuery(BooleanBuilder predicate, Pageable pageable) {
+  private Page<ReviewPageResponseDto> executeQuery(BooleanBuilder predicate, Pageable pageable) {
 
-    List<ReviewPageResponseDTO> content =
+    List<ReviewPageResponseDto> content =
         queryFactory
             .selectFrom(QReview.review)
             .where(predicate)
@@ -86,7 +86,7 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
             .limit(pageable.getPageSize())
             .fetch()
             .stream()
-            .map(ReviewPageResponseDTO::from)
+            .map(ReviewPageResponseDto::from)
             .toList();
 
     long total = queryFactory.selectFrom(QReview.review).where(predicate).fetchCount();

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.chone.server.domains.review.repository;
 
 import com.chone.server.domains.review.domain.QReview;
 import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
-import com.chone.server.domains.review.dto.response.ReviewPageResponse;
+import com.chone.server.domains.review.dto.response.ReviewPageResponseDTO;
 import com.chone.server.domains.user.domain.User;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -20,7 +20,7 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public Page<ReviewPageResponse> findReviewsByCustomer(
+  public Page<ReviewPageResponseDTO> findReviewsByCustomer(
       User customer, ReviewListRequestDTO filterParams, Pageable pageable) {
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
@@ -33,7 +33,7 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   }
 
   @Override
-  public Page<ReviewPageResponse> findReviewsByOwner(
+  public Page<ReviewPageResponseDTO> findReviewsByOwner(
       User owner, ReviewListRequestDTO filterParams, Pageable pageable) {
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
@@ -46,7 +46,7 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   }
 
   @Override
-  public Page<ReviewPageResponse> findReviewsByManagerOrMaster(
+  public Page<ReviewPageResponseDTO> findReviewsByManagerOrMaster(
       User user, ReviewListRequestDTO filterParams, Pageable pageable) { // ✅ User 인자 추가!
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
@@ -75,9 +75,9 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
     }
   }
 
-  private Page<ReviewPageResponse> executeQuery(BooleanBuilder predicate, Pageable pageable) {
+  private Page<ReviewPageResponseDTO> executeQuery(BooleanBuilder predicate, Pageable pageable) {
 
-    List<ReviewPageResponse> content =
+    List<ReviewPageResponseDTO> content =
         queryFactory
             .selectFrom(QReview.review)
             .where(predicate)
@@ -86,7 +86,7 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
             .limit(pageable.getPageSize())
             .fetch()
             .stream()
-            .map(ReviewPageResponse::from)
+            .map(ReviewPageResponseDTO::from)
             .toList();
 
     long total = queryFactory.selectFrom(QReview.review).where(predicate).fetchCount();

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,96 @@
+package com.chone.server.domains.review.repository;
+
+import com.chone.server.domains.review.domain.QReview;
+import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
+import com.chone.server.domains.review.dto.response.ReviewPageResponse;
+import com.chone.server.domains.user.domain.User;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewSearchRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<ReviewPageResponse> findReviewsByCustomer(
+      User customer, ReviewListRequestDTO filterParams, Pageable pageable) {
+    QReview review = QReview.review;
+    BooleanBuilder predicate = new BooleanBuilder();
+
+    predicate.and(review.user.id.eq(customer.getId()).or(review.isPublic.isTrue()));
+
+    applyFilters(predicate, filterParams, review);
+
+    return executeQuery(predicate, pageable);
+  }
+
+  @Override
+  public Page<ReviewPageResponse> findReviewsByOwner(
+      User owner, ReviewListRequestDTO filterParams, Pageable pageable) {
+    QReview review = QReview.review;
+    BooleanBuilder predicate = new BooleanBuilder();
+
+    predicate.and(review.store.user.id.eq(owner.getId()).or(review.isPublic.isTrue()));
+
+    applyFilters(predicate, filterParams, review);
+
+    return executeQuery(predicate, pageable);
+  }
+
+  @Override
+  public Page<ReviewPageResponse> findReviewsByManagerOrMaster(
+      User user, ReviewListRequestDTO filterParams, Pageable pageable) { // ✅ User 인자 추가!
+    QReview review = QReview.review;
+    BooleanBuilder predicate = new BooleanBuilder();
+
+    applyFilters(predicate, filterParams, review);
+
+    return executeQuery(predicate, pageable);
+  }
+
+  private void applyFilters(
+      BooleanBuilder predicate, ReviewListRequestDTO filterParams, QReview review) {
+    if (filterParams.getStoreId() != null) {
+      predicate.and(review.store.id.eq(filterParams.getStoreId()));
+    }
+    if (filterParams.getOrderId() != null) {
+      predicate.and(review.order.id.eq(filterParams.getOrderId()));
+    }
+    if (filterParams.getMinRating() != null) {
+      predicate.and(review.rating.goe(filterParams.getMinRating()));
+    }
+    if (filterParams.getMaxRating() != null) {
+      predicate.and(review.rating.loe(filterParams.getMaxRating()));
+    }
+    if (filterParams.getHasImage() != null && filterParams.getHasImage()) {
+      predicate.and(review.imageUrl.isNotNull());
+    }
+  }
+
+  private Page<ReviewPageResponse> executeQuery(BooleanBuilder predicate, Pageable pageable) {
+
+    List<ReviewPageResponse> content =
+        queryFactory
+            .selectFrom(QReview.review)
+            .where(predicate)
+            .orderBy(QReview.review.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch()
+            .stream()
+            .map(ReviewPageResponse::from)
+            .toList();
+
+    long total = queryFactory.selectFrom(QReview.review).where(predicate).fetchCount();
+
+    return new PageImpl<>(content, pageable, total);
+  }
+}

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
@@ -1,18 +1,18 @@
 package com.chone.server.domains.review.repository;
 
 import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
-import com.chone.server.domains.review.dto.response.ReviewPageResponse;
+import com.chone.server.domains.review.dto.response.ReviewPageResponseDTO;
 import com.chone.server.domains.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReviewSearchRepository {
-  Page<ReviewPageResponse> findReviewsByCustomer(
+  Page<ReviewPageResponseDTO> findReviewsByCustomer(
       User customer, ReviewListRequestDTO filterParams, Pageable pageable);
 
-  Page<ReviewPageResponse> findReviewsByOwner(
+  Page<ReviewPageResponseDTO> findReviewsByOwner(
       User owner, ReviewListRequestDTO filterParams, Pageable pageable);
 
-  Page<ReviewPageResponse> findReviewsByManagerOrMaster(
+  Page<ReviewPageResponseDTO> findReviewsByManagerOrMaster(
       User managerOrMaster, ReviewListRequestDTO filterParams, Pageable pageable);
 }

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
@@ -1,0 +1,18 @@
+package com.chone.server.domains.review.repository;
+
+import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
+import com.chone.server.domains.review.dto.response.ReviewPageResponse;
+import com.chone.server.domains.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewSearchRepository {
+  Page<ReviewPageResponse> findReviewsByCustomer(
+      User customer, ReviewListRequestDTO filterParams, Pageable pageable);
+
+  Page<ReviewPageResponse> findReviewsByOwner(
+      User owner, ReviewListRequestDTO filterParams, Pageable pageable);
+
+  Page<ReviewPageResponse> findReviewsByManagerOrMaster(
+      User managerOrMaster, ReviewListRequestDTO filterParams, Pageable pageable);
+}

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
@@ -1,18 +1,18 @@
 package com.chone.server.domains.review.repository;
 
-import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
-import com.chone.server.domains.review.dto.response.ReviewPageResponseDTO;
+import com.chone.server.domains.review.dto.request.ReviewListRequestDto;
+import com.chone.server.domains.review.dto.response.ReviewPageResponseDto;
 import com.chone.server.domains.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReviewSearchRepository {
-  Page<ReviewPageResponseDTO> findReviewsByCustomer(
-      User customer, ReviewListRequestDTO filterParams, Pageable pageable);
+  Page<ReviewPageResponseDto> findReviewsByCustomer(
+      User customer, ReviewListRequestDto filterParams, Pageable pageable);
 
-  Page<ReviewPageResponseDTO> findReviewsByOwner(
-      User owner, ReviewListRequestDTO filterParams, Pageable pageable);
+  Page<ReviewPageResponseDto> findReviewsByOwner(
+      User owner, ReviewListRequestDto filterParams, Pageable pageable);
 
-  Page<ReviewPageResponseDTO> findReviewsByManagerOrMaster(
-      User managerOrMaster, ReviewListRequestDTO filterParams, Pageable pageable);
+  Page<ReviewPageResponseDto> findReviewsByManagerOrMaster(
+      User managerOrMaster, ReviewListRequestDto filterParams, Pageable pageable);
 }

--- a/src/main/java/com/chone/server/domains/review/service/ReviewService.java
+++ b/src/main/java/com/chone/server/domains/review/service/ReviewService.java
@@ -19,9 +19,11 @@ import com.chone.server.domains.user.domain.User;
 import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReviewService {

--- a/src/main/java/com/chone/server/domains/review/service/ReviewService.java
+++ b/src/main/java/com/chone/server/domains/review/service/ReviewService.java
@@ -6,10 +6,10 @@ import com.chone.server.domains.order.domain.Order;
 import com.chone.server.domains.order.domain.OrderStatus;
 import com.chone.server.domains.order.repository.OrderRepository;
 import com.chone.server.domains.review.domain.Review;
-import com.chone.server.domains.review.dto.request.CreateRequestDTO;
-import com.chone.server.domains.review.dto.request.ReviewListRequestDTO;
+import com.chone.server.domains.review.dto.request.CreateRequestDto;
+import com.chone.server.domains.review.dto.request.ReviewListRequestDto;
 import com.chone.server.domains.review.dto.response.ReviewListResponseDto;
-import com.chone.server.domains.review.dto.response.ReviewResponseDTO;
+import com.chone.server.domains.review.dto.response.ReviewResponseDto;
 import com.chone.server.domains.review.exception.ReviewExceptionCode;
 import com.chone.server.domains.review.repository.ReviewRepository;
 import com.chone.server.domains.review.repository.ReviewSearchRepository;
@@ -32,7 +32,7 @@ public class ReviewService {
   private final ReviewSearchRepository reviewSearchRepository;
 
   @Transactional
-  public ReviewResponseDTO createReview(CreateRequestDTO request, User user) {
+  public ReviewResponseDto createReview(CreateRequestDto request, User user) {
 
     Order order = orderRepository.findById(request.getOrderId());
     if (order == null) {
@@ -68,11 +68,11 @@ public class ReviewService {
 
     Review savedReview = reviewRepository.save(review);
 
-    return new ReviewResponseDTO(savedReview.getId(), savedReview.getCreatedAt());
+    return new ReviewResponseDto(savedReview.getId(), savedReview.getCreatedAt());
   }
 
   public ReviewListResponseDto getReviews(
-      ReviewListRequestDTO request, CustomUserDetails principal, Pageable pageable) {
+      ReviewListRequestDto request, CustomUserDetails principal, Pageable pageable) {
     User user = principal.getUser();
 
     return switch (user.getRole()) {

--- a/src/main/java/com/chone/server/domains/review/service/ReviewService.java
+++ b/src/main/java/com/chone/server/domains/review/service/ReviewService.java
@@ -39,9 +39,6 @@ public class ReviewService {
   public ReviewResponseDto createReview(CreateRequestDto request, User user) {
 
     Order order = orderRepository.findById(request.getOrderId());
-    if (order == null) {
-      throw new ApiBusinessException(ReviewExceptionCode.ORDER_NOT_FOUND);
-    }
 
     Store store =
         storeRepository


### PR DESCRIPTION
## 📢 개요

권한에 따른 리뷰 목록 조회와 상세 목록 조회 API를 구현했습니다

## 📝 작업 내용
- 필터링을 적용하여 storeId, orderId, minRating, maxRating 조건 검색 
- 권한 기반 필터링 로직 적용
  - CUSTOMER: 본인 작성 리뷰 + isPublic = true 조회 가능
  - OWNER: 본인의 가게 리뷰(공개/비공개) + 모든 isPublic = true 조회 가능
  - MANAGER, MASTER: 모든 리뷰 조회 가능
- 페이징 및 정렬 구현

### 변경 사항

- @RequestParam을 활용하여 DTO 변환 방식 개선  
- 필터링 기능 (`minRating`, `maxRating`, `hasImage`, `storeId`, `orderId`, `startDate`, `endDate`)  
- 역할(Role)별 데이터 접근 권한 처리 (`CUSTOMER`, `OWNER`, `MANAGER`, `MASTER`)  
- 존재하지 않는 리뷰 요청 시 `404 REVIEW_NOT_FOUND` 예외 발생
- 본인이 작성하지 않은 비공개 리뷰 접근 차단 (`403 REVIEW_ACCESS_DENIED`)

### 변경 이유

### 추가 설명

## 💬리뷰 요구사항
- QueryDSL을 활용한 동적 필터링이 적절하게 적용되었는지 검토
- 권한 기반 조회 로직이 적절한지 확인 (CUSTOMER, OWNER, MANAGER/MASTER)
- 페이징, 정렬 기능 (size, page, sort, direction) 정상 동작 여부 검토

 **테스트 완료**  
- 기본 리뷰 조회 (페이지네이션, 기본 정렬 `createdAt desc`)  
- 평점 기준 정렬 (`rating asc`, `rating desc`)  
- 필터링 기능 (`minRating`, `maxRating`, `hasImage`, `storeId`, `orderId`)  
- 권한별 데이터 접근 테스트 (`CUSTOMER`, `OWNER`, `MANAGER`, `MASTER`) 
- 리뷰 목록 조회 성공 (`GET /api/v1/reviews`)
- 리뷰 상세 조회 성공 (`GET /api/v1/reviews/{id}`)
- 존재하지 않는 리뷰 요청 시 `404 REVIEW_NOT_FOUND` 정상 반환
- 비공개 리뷰 접근 시 `403 REVIEW_ACCESS_DENIED` 정상 반환 

#### #️⃣ 연관된 이슈

closed #42 
closed #43

## 📃 PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 추가
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항
- [ ] 기타

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
