### PR TITLE
Feat: 리뷰 삭제 API 추가

### DIFF
--- a/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
+++ b/src/main/java/com/chone/server/domains/review/controller/ReviewController.java
@@ -2,8 +2,10 @@ package com.chone.server.domains.review.controller;
 
 import com.chone.server.domains.auth.dto.CustomUserDetails;
 import com.chone.server.domains.review.dto.request.CreateRequestDto;
+import com.chone.server.domains.review.dto.request.DeleteRequestDto;
 import com.chone.server.domains.review.dto.request.ReviewListRequestDto;
 import com.chone.server.domains.review.dto.request.UpdateRequestDto;
+import com.chone.server.domains.review.dto.response.ReviewDeleteResponseDto;
 import com.chone.server.domains.review.dto.response.ReviewDetailResponseDto;
 import com.chone.server.domains.review.dto.response.ReviewListResponseDto;
 import com.chone.server.domains.review.dto.response.ReviewResponseDto;
@@ -63,6 +65,17 @@ public class ReviewController {
       @AuthenticationPrincipal CustomUserDetails principal) {
 
     ReviewUpdateResponseDto response = reviewService.updateReview(id, request, principal);
+    return ResponseEntity.ok(response);
+  }
+
+  @PreAuthorize("hasAnyRole('CUSTOMER', 'MANAGER', 'MASTER')")
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ReviewDeleteResponseDto> deleteReview(
+      @PathVariable("id") UUID id,
+      @AuthenticationPrincipal CustomUserDetails principal,
+      @RequestBody(required = false) @Valid DeleteRequestDto requestDto) {
+
+    ReviewDeleteResponseDto response = reviewService.deleteReview(id, principal, requestDto);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/chone/server/domains/review/domain/Review.java
+++ b/src/main/java/com/chone/server/domains/review/domain/Review.java
@@ -90,4 +90,10 @@ public class Review extends BaseEntity {
     if (hasText(imageUrl)) this.imageUrl = imageUrl;
     if (isPublic != null) this.isPublic = isPublic;
   }
+
+  public void softDelete(User user, String reason) {
+
+    this.delete(user);
+    this.deletedReason = reason;
+  }
 }

--- a/src/main/java/com/chone/server/domains/review/dto/request/DeleteRequestDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/request/DeleteRequestDto.java
@@ -1,0 +1,11 @@
+package com.chone.server.domains.review.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeleteRequestDto {
+
+  private String reason;
+}

--- a/src/main/java/com/chone/server/domains/review/dto/response/ReviewDeleteResponseDto.java
+++ b/src/main/java/com/chone/server/domains/review/dto/response/ReviewDeleteResponseDto.java
@@ -1,0 +1,14 @@
+package com.chone.server.domains.review.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReviewDeleteResponseDto {
+
+  private UUID reviewId;
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/chone/server/domains/review/exception/ReviewExceptionCode.java
+++ b/src/main/java/com/chone/server/domains/review/exception/ReviewExceptionCode.java
@@ -14,6 +14,7 @@ public enum ReviewExceptionCode implements ExceptionCode {
   // 400 BAD_REQUEST
   INVALID_PARAMETER(BAD_REQUEST, "요청 파라미터가 유효하지 않습니다."),
   INVALID_CONTENT(BAD_REQUEST, "리뷰 내용은 5자 이상이어야 합니다."),
+  INVALID_REQUEST(BAD_REQUEST, "관리자 삭제 요청 시 사유를 반드시 입력해야 합니다."),
 
   // 401 UNAUTHORIZED
   REVIEW_UNAUTHORIZED(UNAUTHORIZED, "인증이 필요한 요청입니다."),
@@ -22,6 +23,7 @@ public enum ReviewExceptionCode implements ExceptionCode {
   REVIEW_FORBIDDEN(FORBIDDEN, "주문한 고객만 리뷰를 작성할 수 있습니다."),
   REVIEW_FORBIDDEN_ACTION(FORBIDDEN, "리뷰 작성자가 아닌 사용자는 해당 작업을 수행할 수 없습니다."),
   REVIEW_UPDATE_EXPIRED(FORBIDDEN, "리뷰는 작성 후 3일 이내에만 수정할 수 있습니다."),
+  REVIEW_DELETE_FORBIDDEN(FORBIDDEN, "해당 요청을 수행할 권한이 없습니다."),
 
   // 404 NOT_FOUND
   REVIEW_NOT_FOUND(NOT_FOUND, "요청하신 리뷰 정보를 찾을 수 없습니다."),
@@ -30,6 +32,7 @@ public enum ReviewExceptionCode implements ExceptionCode {
 
   // 409 CONFLICT
   REVIEW_ALREADY_EXISTS(CONFLICT, "해당 주문에 대한 리뷰가 이미 존재합니다."),
+  ALREADY_DELETED(CONFLICT, "이미 삭제된 리뷰입니다."),
 
   // 422 UNPROCESSABLE_ENTITY
   INVALID_RATING(UNPROCESSABLE_ENTITY, "평점 값은 1에서 5 사이의 숫자여야 합니다."),

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewRepository.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
   Optional<Review> findByOrderId(UUID orderId);
+
+  Optional<Review> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewRepositoryImpl.java
@@ -27,9 +27,11 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   @Override
   public Page<ReviewPageResponseDto> findReviewsByCustomer(
       User customer, ReviewListRequestDto filterParams, Pageable pageable) {
+
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
 
+    predicate.and(review.deletedAt.isNull());
     predicate.and(review.user.id.eq(customer.getId()).or(review.isPublic.isTrue()));
 
     applyFilters(predicate, filterParams, review);
@@ -40,9 +42,11 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   @Override
   public Page<ReviewPageResponseDto> findReviewsByOwner(
       User owner, ReviewListRequestDto filterParams, Pageable pageable) {
+
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
 
+    predicate.and(review.deletedAt.isNull());
     predicate.and(review.store.user.id.eq(owner.getId()).or(review.isPublic.isTrue()));
 
     applyFilters(predicate, filterParams, review);
@@ -53,8 +57,11 @@ public class ReviewRepositoryImpl implements ReviewSearchRepository {
   @Override
   public Page<ReviewPageResponseDto> findReviewsByManagerOrMaster(
       User user, ReviewListRequestDto filterParams, Pageable pageable) {
+
     QReview review = QReview.review;
     BooleanBuilder predicate = new BooleanBuilder();
+
+    predicate.and(review.deletedAt.isNull());
 
     applyFilters(predicate, filterParams, review);
 

--- a/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
+++ b/src/main/java/com/chone/server/domains/review/repository/ReviewSearchRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReviewSearchRepository {
+
   Page<ReviewPageResponseDto> findReviewsByCustomer(
       User customer, ReviewListRequestDto filterParams, Pageable pageable);
 


### PR DESCRIPTION
## 📢 개요

리뷰 데이터에 Soft Delete 적용 및 삭제 API 추가했습니다.

## 📝 작업 내용

- 리뷰 삭제 API 추가
- 삭제된 리뷰는 조회 불가 (deletedAt IS NULL 조건 적용)

### 변경 사항

1. **ReviewController.java
- `DELETE /api/v1/reviews/{id}` API 추가  

2. ReviewService.java
  - Soft Delete 로직 적용 (`BaseEntity.delete()` 사용)  
  - `deletedAt` 및 `deletedBy` 저장  
  - `MANAGER/MASTER` 삭제 시 `deletedReason` 저장  
  - 삭제된 리뷰는 조회 불가 (`REVIEW_NOT_FOUND` 예외 처리)

3. ReviewRepository.java
- `findByIdAndDeletedAtIsNull(UUID id)`: 삭제되지 않은 리뷰만 조회

4. ReviewSearchRepositoryImpl.java
- Soft Delete 적용 (`deletedAt IS NULL` 조건 추가)  
- 모든 조회 쿼리에 `deletedAt IS NULL` 조건 추가

5. Review.java
- Soft Delete 적용을 위한 `softDelete(User user, String reason)` 메서드 추가  
 - `deletedAt`, `deletedBy`, `deletedReason` 저장  

6. ReviewExceptionCode.java
- `ALREADY_DELETED(409)`: 이미 삭제된 리뷰 예외 처리  
- `INVALID_REQUEST(400)`: 관리자 삭제 시 `reason` 누락 예외 처리

7. DTO 추가
- **DeleteReviewRequestDto**  
  - 관리자 삭제 시 `reason` 필드 사용  

- **DeleteReviewResponseDto**  
  - 삭제된 리뷰 ID (`reviewId`) 및 삭제 시각 (`deletedAt`) 반환


### 변경 이유

### 추가 설명

## 💬리뷰 요구사항

- [x] `CUSTOMER`: 본인 리뷰만 삭제 가능  
- [x] `MANAGER/MASTER`: 모든 리뷰 삭제 가능 (`reason` 필수 입력)  
 
 - 이유 입력 안 할 시 에러 발생
![image](https://github.com/user-attachments/assets/eb3fd27b-9dbc-4ae8-aa8f-b770213b3209)



#### #️⃣ 연관된 이슈

closed #46 

## 📃 PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 추가
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항
- [ ] 기타

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
