### PR TITLE
Feat: 결제 취소 기능 구현

### DIFF
--- a/src/main/java/com/chone/server/domains/order/domain/OrderCancelReason.java
+++ b/src/main/java/com/chone/server/domains/order/domain/OrderCancelReason.java
@@ -15,6 +15,7 @@ public enum OrderCancelReason {
   POLICY_VIOLATION(7, "정책 위반"),
   ADMIN_APPROVED_CANCEL(8, "고객 요청 승인"),
   ADMIN_DECISION(9, "관리자 판단"),
+  CANCEL_PAYMENT(10, "결제취소"),
 
   OTHER(99, "기타");
 

--- a/src/main/java/com/chone/server/domains/order/exception/OrderExceptionCode.java
+++ b/src/main/java/com/chone/server/domains/order/exception/OrderExceptionCode.java
@@ -33,7 +33,9 @@ public enum OrderExceptionCode implements ExceptionCode {
   ORDER_ALREADY_CANCELED(BAD_REQUEST, "이미 취소된 주문입니다."),
   ORDER_NOT_CANCELABLE(BAD_REQUEST, "취소할 수 없는 주문입니다."),
   ORDER_NOT_DELETABLE(CONFLICT, "주문 과정이 완료되지 않아 삭제할 수 없는 주문입니다."),
-  ;
+
+  ORDER_ALREADY_IN_DELIVERY(CONFLICT, "배달 중인 주문은 취소할 수 없습니다."),
+  ORDER_ALREADY_COMPLETED(CONFLICT, "완료된 주문은 취소할 수 없습니다");
   private final HttpStatus status;
   private final String message;
   private final String code = this.name();

--- a/src/main/java/com/chone/server/domains/order/service/OrderDomainService.java
+++ b/src/main/java/com/chone/server/domains/order/service/OrderDomainService.java
@@ -150,6 +150,14 @@ public class OrderDomainService {
       throw new ApiBusinessException(OrderExceptionCode.ORDER_ALREADY_CANCELED);
     }
 
+    if (order.getStatus() == OrderStatus.IN_DELIVERY) {
+      throw new ApiBusinessException(OrderExceptionCode.ORDER_ALREADY_IN_DELIVERY);
+    }
+
+    if (order.getStatus() == OrderStatus.COMPLETED) {
+      throw new ApiBusinessException(OrderExceptionCode.ORDER_ALREADY_COMPLETED);
+    }
+
     if (!order.isCancelable()) {
       throw new ApiBusinessException(OrderExceptionCode.ORDER_NOT_CANCELABLE);
     }

--- a/src/main/java/com/chone/server/domains/payment/controller/PaymentController.java
+++ b/src/main/java/com/chone/server/domains/payment/controller/PaymentController.java
@@ -3,11 +3,14 @@ package com.chone.server.domains.payment.controller;
 import com.chone.server.commons.util.UriGeneratorUtil;
 import com.chone.server.domains.auth.dto.CustomUserDetails;
 import com.chone.server.domains.order.dto.response.PageResponse;
+import com.chone.server.domains.payment.dto.request.CancelPaymentRequest;
 import com.chone.server.domains.payment.dto.request.CreatePaymentRequest;
 import com.chone.server.domains.payment.dto.request.PaymentFilterParams;
+import com.chone.server.domains.payment.dto.response.CancelPaymentResponse;
 import com.chone.server.domains.payment.dto.response.CreatePaymentResponse;
 import com.chone.server.domains.payment.dto.response.PaymentDetailResponse;
 import com.chone.server.domains.payment.dto.response.PaymentPageResponse;
+import com.chone.server.domains.payment.service.PaymentCancellationService;
 import com.chone.server.domains.payment.service.PaymentProcessService;
 import com.chone.server.domains.payment.service.PaymentReadService;
 import jakarta.validation.Valid;
@@ -20,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PaymentController {
   private final PaymentProcessService processService;
   private final PaymentReadService readService;
+  private final PaymentCancellationService cancellationService;
 
   @PostMapping
   public ResponseEntity<CreatePaymentResponse> createOrder(
@@ -59,6 +64,17 @@ public class PaymentController {
   public ResponseEntity<PaymentDetailResponse> getPayment(
       @AuthenticationPrincipal CustomUserDetails principal, @PathVariable("id") UUID id) {
     PaymentDetailResponse responseDto = readService.getPaymentById(principal, id);
+
+    return ResponseEntity.ok().body(responseDto);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<CancelPaymentResponse> cancelPayment(
+      @AuthenticationPrincipal CustomUserDetails principal,
+      @PathVariable("id") UUID id,
+      @Valid @RequestBody CancelPaymentRequest requestDto) {
+    CancelPaymentResponse responseDto =
+        cancellationService.cancelPayment(principal, id, requestDto);
 
     return ResponseEntity.ok().body(responseDto);
   }

--- a/src/main/java/com/chone/server/domains/payment/controller/PaymentController.java
+++ b/src/main/java/com/chone/server/domains/payment/controller/PaymentController.java
@@ -8,7 +8,8 @@ import com.chone.server.domains.payment.dto.request.PaymentFilterParams;
 import com.chone.server.domains.payment.dto.response.CreatePaymentResponse;
 import com.chone.server.domains.payment.dto.response.PaymentDetailResponse;
 import com.chone.server.domains.payment.dto.response.PaymentPageResponse;
-import com.chone.server.domains.payment.service.PaymentService;
+import com.chone.server.domains.payment.service.PaymentProcessService;
+import com.chone.server.domains.payment.service.PaymentReadService;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,13 +30,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/payments")
 public class PaymentController {
-  private final PaymentService service;
+  private final PaymentProcessService processService;
+  private final PaymentReadService readService;
 
   @PostMapping
   public ResponseEntity<CreatePaymentResponse> createOrder(
       @Valid @RequestBody CreatePaymentRequest requestDto,
       @AuthenticationPrincipal CustomUserDetails principal) {
-    CreatePaymentResponse responseDto = service.processPayment(requestDto, principal);
+    CreatePaymentResponse responseDto = processService.processPayment(requestDto, principal);
 
     return ResponseEntity.created(UriGeneratorUtil.generateUri("/" + responseDto.id().toString()))
         .body(responseDto);
@@ -48,15 +50,15 @@ public class PaymentController {
       @PageableDefault(page = 0, size = 10, sort = "createdat", direction = Sort.Direction.DESC)
           Pageable pageable) {
     PageResponse<PaymentPageResponse> responseDto =
-        service.getPayments(principal, filterParams, pageable);
+        readService.getPayments(principal, filterParams, pageable);
 
     return ResponseEntity.ok().body(responseDto);
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<PaymentDetailResponse> getOrder(
+  public ResponseEntity<PaymentDetailResponse> getPayment(
       @AuthenticationPrincipal CustomUserDetails principal, @PathVariable("id") UUID id) {
-    PaymentDetailResponse responseDto = service.getPaymentById(principal, id);
+    PaymentDetailResponse responseDto = readService.getPaymentById(principal, id);
 
     return ResponseEntity.ok().body(responseDto);
   }

--- a/src/main/java/com/chone/server/domains/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/chone/server/domains/payment/domain/PaymentStatus.java
@@ -7,9 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PaymentStatus {
   PENDING("결제 대기 중"),
-  ACCEPTED("결제 승인됨"),
   COMPLETED("결제 완료"),
-  CANCEL_REQUESTED("결제 취소 요청됨"),
   CANCELED("결제 취소됨"),
   FAILED("결제 실패");
   private final String description;

--- a/src/main/java/com/chone/server/domains/payment/domain/PgPaymentLog.java
+++ b/src/main/java/com/chone/server/domains/payment/domain/PgPaymentLog.java
@@ -65,4 +65,8 @@ public class PgPaymentLog extends BaseEntity {
         .pgStatus(pgStatus)
         .responseMessage(responseMessage);
   }
+
+  public void cancel() {
+    this.pgStatus = PgStatus.CANCEL_SUCCESS;
+  }
 }

--- a/src/main/java/com/chone/server/domains/payment/domain/PgStatus.java
+++ b/src/main/java/com/chone/server/domains/payment/domain/PgStatus.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PgStatus {
-  SUCCESS("PG사 승인됨"),
-  FAILED("PG사 처리 실패"),
-  ERROR("처리 중 오류"),
-  PENDING("PG사 처리 대기");
+  PROCESSING_SUCCESS("결제 처리 성공"),
+  PROCESSING_FAILED("결제 처리 실패"),
+  PROCESSING_ERROR("결제 처리 중 오류"),
+
+  CANCEL_SUCCESS("결제 취소 성공"),
+  CANCEL_FAILED("결제 취소 실패"),
+  CANCEL_ERROR("결제 취소 오류");
 
   private final String description;
 }

--- a/src/main/java/com/chone/server/domains/payment/dto/request/CancelPaymentRequest.java
+++ b/src/main/java/com/chone/server/domains/payment/dto/request/CancelPaymentRequest.java
@@ -1,0 +1,8 @@
+package com.chone.server.domains.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CancelPaymentRequest(
+    @NotBlank(message = "취소 이유는 필수입니다.") @Size(max = 25, message = "취소 이유는 25자 내로 작성할 수 있습니다.")
+        String reason) {}

--- a/src/main/java/com/chone/server/domains/payment/dto/response/CancelPaymentResponse.java
+++ b/src/main/java/com/chone/server/domains/payment/dto/response/CancelPaymentResponse.java
@@ -1,0 +1,15 @@
+package com.chone.server.domains.payment.dto.response;
+
+import com.chone.server.domains.payment.domain.Payment;
+import java.time.LocalDateTime;
+
+public record CancelPaymentResponse(
+    boolean isSuccess, String status, LocalDateTime cancelRequestedAt) {
+  private CancelPaymentResponse(boolean isSuccess, Payment payment) {
+    this(isSuccess, payment.getStatus().getDescription(), payment.getUpdatedAt());
+  }
+
+  public static CancelPaymentResponse from(boolean isSuccess, Payment payment) {
+    return new CancelPaymentResponse(isSuccess, payment);
+  }
+}

--- a/src/main/java/com/chone/server/domains/payment/dto/response/PaymentDetailResponse.java
+++ b/src/main/java/com/chone/server/domains/payment/dto/response/PaymentDetailResponse.java
@@ -1,5 +1,6 @@
 package com.chone.server.domains.payment.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.UUID;
 
 public record PaymentDetailResponse(PaymentResponse payment, OrderResponse order) {
@@ -12,5 +13,5 @@ public record PaymentDetailResponse(PaymentResponse payment, OrderResponse order
       Long userId,
       UUID storeId,
       String storeName,
-      Long storeUserId) {}
+      @JsonIgnore Long storeUserId) {}
 }

--- a/src/main/java/com/chone/server/domains/payment/exception/PaymentExceptionCode.java
+++ b/src/main/java/com/chone/server/domains/payment/exception/PaymentExceptionCode.java
@@ -3,7 +3,9 @@ package com.chone.server.domains.payment.exception;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 
 import com.chone.server.commons.exception.ExceptionCode;
 import lombok.Getter;
@@ -31,11 +33,17 @@ public enum PaymentExceptionCode implements ExceptionCode {
   CANCELED_ORDER(BAD_REQUEST, "취소된 주문은 결제할 수 없습니다."),
   PRICE_MISMATCH(BAD_REQUEST, "결제 금액이 주문 금액과 일치하지 않습니다."),
 
-  PAYMENT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다."),
-  PAYMENT_IN_PROGRESS(HttpStatus.SERVICE_UNAVAILABLE, "결제가 진행 중입니다. 잠시 후 다시 시도해주세요."),
-  PAYMENT_GATEWAY_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "결제 시스템 연동 중 오류가 발생했습니다."),
-  ;
+  PAYMENT_PROCESSING_ERROR(INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다."),
+  PAYMENT_IN_PROGRESS(SERVICE_UNAVAILABLE, "결제가 진행 중입니다. 잠시 후 다시 시도해주세요."),
+  PAYMENT_GATEWAY_ERROR(SERVICE_UNAVAILABLE, "결제 시스템 연동 중 오류가 발생했습니다."),
+  PAYMENT_ALREADY_CANCELED(CONFLICT, "이미 취소된 결제입니다"),
+  FAILED_PAYMENT(BAD_REQUEST, "실패된 결제입니다(결제된 적이 없습니다)."),
+  ORDER_NOT_CANCELABLE(BAD_REQUEST, "주문이 취소될 수 없어 결제를 취소할 수 없습니다."),
 
+  PAYMENT_CANCELLATION_IN_PROGRESS(SERVICE_UNAVAILABLE, "결제 취소가 진행 중입니다. 잠시 후 다시 시도해주세요."),
+  PAYMENT_CANCELLATION_ERROR(INTERNAL_SERVER_ERROR, "결제 취소 처리 중 오류가 발생했습니다."),
+
+  PAYMENT_CANCELLATION_FAILED(SERVICE_UNAVAILABLE, "결제 취소 요청이 거부되었습니다.");
   private final HttpStatus status;
   private final String message;
   private final String code = this.name();

--- a/src/main/java/com/chone/server/domains/payment/infrastructure/jpa/PgPaymentLogJpaRepository.java
+++ b/src/main/java/com/chone/server/domains/payment/infrastructure/jpa/PgPaymentLogJpaRepository.java
@@ -1,5 +1,6 @@
 package com.chone.server.domains.payment.infrastructure.jpa;
 
+import com.chone.server.domains.payment.domain.Payment;
 import com.chone.server.domains.payment.domain.PgPaymentLog;
 import java.util.Optional;
 import java.util.UUID;
@@ -7,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PgPaymentLogJpaRepository extends JpaRepository<PgPaymentLog, UUID> {
   Optional<PgPaymentLog> findByIdAndDeletedAtNull(UUID id);
+
+  Optional<PgPaymentLog> findByPaymentAndDeletedAtNull(Payment id);
 }

--- a/src/main/java/com/chone/server/domains/payment/infrastructure/jpa/PgPaymentLogRepositoryImpl.java
+++ b/src/main/java/com/chone/server/domains/payment/infrastructure/jpa/PgPaymentLogRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.chone.server.domains.payment.infrastructure.jpa;
 
 import com.chone.server.commons.exception.ApiBusinessException;
+import com.chone.server.domains.payment.domain.Payment;
 import com.chone.server.domains.payment.domain.PgPaymentLog;
 import com.chone.server.domains.payment.exception.PgPaymentLogExceptionCode;
 import com.chone.server.domains.payment.repository.PgPaymentLogRepository;
@@ -17,6 +18,14 @@ public class PgPaymentLogRepositoryImpl implements PgPaymentLogRepository {
   public PgPaymentLog findById(UUID id) {
     return jpaRepository
         .findByIdAndDeletedAtNull(id)
+        .orElseThrow(
+            () -> new ApiBusinessException(PgPaymentLogExceptionCode.NOT_FOUND_PG_PAYMENT_LOG));
+  }
+
+  @Override
+  public PgPaymentLog findByPayment(Payment payment) {
+    return jpaRepository
+        .findByPaymentAndDeletedAtNull(payment)
         .orElseThrow(
             () -> new ApiBusinessException(PgPaymentLogExceptionCode.NOT_FOUND_PG_PAYMENT_LOG));
   }

--- a/src/main/java/com/chone/server/domains/payment/infrastructure/pg/PgApiService.java
+++ b/src/main/java/com/chone/server/domains/payment/infrastructure/pg/PgApiService.java
@@ -7,14 +7,19 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class PgApiService {
+
   public Map<String, String> requestPayment() {
     return new MockPgController().processPayment();
   }
 
+  public Map<String, String> requestCancel() {
+    return new MockPgController().processCancel();
+  }
+
   class MockPgController {
+
     public Map<String, String> processPayment() {
-      //      boolean isSuccess = Math.random() > 0.2;
-      boolean isSuccess = false;
+      boolean isSuccess = true;
       String status = isSuccess ? "success" : "fail";
       String message =
           "저희 서비스의 %s로 결제가 %s했습니다."
@@ -26,6 +31,20 @@ public class PgApiService {
       if (isSuccess) {
         response.put("transactionId", RandomStringUtils.randomAlphabetic(10));
       }
+      return response;
+    }
+
+    public Map<String, String> processCancel() {
+      boolean isSuccess = false;
+      String status = isSuccess ? "success" : "fail";
+      String message =
+          "저희 서비스의 %s로 결제 취소가 %s했습니다."
+              .formatted(isSuccess ? "정상 작동" : "오류", isSuccess ? "성공" : "실패");
+
+      Map<String, String> response = new HashMap<>();
+      response.put("status", status);
+      response.put("message", message);
+
       return response;
     }
   }

--- a/src/main/java/com/chone/server/domains/payment/repository/PgPaymentLogRepository.java
+++ b/src/main/java/com/chone/server/domains/payment/repository/PgPaymentLogRepository.java
@@ -1,10 +1,13 @@
 package com.chone.server.domains.payment.repository;
 
+import com.chone.server.domains.payment.domain.Payment;
 import com.chone.server.domains.payment.domain.PgPaymentLog;
 import java.util.UUID;
 
 public interface PgPaymentLogRepository {
   PgPaymentLog findById(UUID id);
+
+  PgPaymentLog findByPayment(Payment payment);
 
   PgPaymentLog save(PgPaymentLog pgPaymentLog);
 }

--- a/src/main/java/com/chone/server/domains/payment/service/PaymentCancellationService.java
+++ b/src/main/java/com/chone/server/domains/payment/service/PaymentCancellationService.java
@@ -1,0 +1,124 @@
+package com.chone.server.domains.payment.service;
+
+import com.chone.server.commons.exception.ApiBusinessException;
+import com.chone.server.commons.lock.DistributedLockTemplate;
+import com.chone.server.domains.auth.dto.CustomUserDetails;
+import com.chone.server.domains.order.domain.Order;
+import com.chone.server.domains.order.domain.OrderCancelReason;
+import com.chone.server.domains.order.service.OrderService;
+import com.chone.server.domains.payment.domain.Payment;
+import com.chone.server.domains.payment.domain.PaymentStatus;
+import com.chone.server.domains.payment.domain.PgPaymentLog;
+import com.chone.server.domains.payment.dto.request.CancelPaymentRequest;
+import com.chone.server.domains.payment.dto.response.CancelPaymentResponse;
+import com.chone.server.domains.payment.exception.PaymentExceptionCode;
+import com.chone.server.domains.payment.infrastructure.pg.PgApiService;
+import com.chone.server.domains.payment.repository.PaymentRepository;
+import com.chone.server.domains.payment.repository.PgPaymentLogRepository;
+import com.chone.server.domains.user.domain.User;
+import jakarta.persistence.LockTimeoutException;
+import jakarta.validation.Valid;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class PaymentCancellationService {
+  private static final String LOCK_KEY_PREFIX = "payment:cancel:";
+  private static final String PG_STATUS_KEY = "status";
+  private static final String PG_MESSAGE_KEY = "message";
+
+  private final PaymentRepository paymentRepository;
+  private final PgPaymentLogRepository pgPaymentLogRepository;
+
+  private final PaymentDomainService domainService;
+  private final OrderService orderService;
+  private final PgApiService pgApiService;
+  private final DistributedLockTemplate lockTemplate;
+
+  @Transactional
+  public CancelPaymentResponse cancelPayment(
+      CustomUserDetails principal, UUID paymentId, @Valid CancelPaymentRequest requestDto) {
+    Payment payment = paymentRepository.findById(paymentId);
+    User currentUser = principal.getUser();
+
+    domainService.validateCancelPaymentRequest(currentUser, payment);
+
+    try {
+      return executeCancellationWithLock(payment, requestDto);
+    } catch (LockTimeoutException e) {
+      throw new ApiBusinessException(PaymentExceptionCode.PAYMENT_CANCELLATION_IN_PROGRESS);
+    } catch (ApiBusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("결제 취소 중 오류 발생: {}", e.getMessage(), e);
+      throw new ApiBusinessException(PaymentExceptionCode.PAYMENT_CANCELLATION_ERROR);
+    }
+  }
+
+  private CancelPaymentResponse executeCancellationWithLock(
+      Payment payment, CancelPaymentRequest requestDto) {
+    return lockTemplate.executeWithLock(
+        LOCK_KEY_PREFIX + payment.getId(),
+        10,
+        TimeUnit.SECONDS,
+        () -> processCancellationTransaction(payment, requestDto));
+  }
+
+  private CancelPaymentResponse processCancellationTransaction(
+      Payment payment, CancelPaymentRequest requestDto) {
+    try {
+      Order cancelOrder = cancelOrder(payment);
+
+      Map<String, String> pgResponse = pgApiService.requestCancel();
+      String status = pgResponse.get(PG_STATUS_KEY);
+      String message = pgResponse.get(PG_MESSAGE_KEY);
+      log.info(message);
+
+      if ("success".equals(status)) {
+        updatePaymentCancellation(payment, requestDto.reason());
+        log.info("결제 취소 완료: paymentId={}, 취소 사유={}", payment.getId(), requestDto.reason());
+        return CancelPaymentResponse.from(true, payment);
+      } else {
+        throw new ApiBusinessException(PaymentExceptionCode.PAYMENT_CANCELLATION_FAILED);
+      }
+    } catch (ApiBusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      logCancellationFailure(e);
+      throw new ApiBusinessException(PaymentExceptionCode.PAYMENT_CANCELLATION_FAILED);
+    }
+  }
+
+  private Order cancelOrder(Payment payment) {
+    // todo listener
+    Order order = orderService.findByOrderId(payment.getOrder().getId());
+    OrderCancelReason cancelReason = OrderCancelReason.CANCEL_PAYMENT;
+    order.cancel(cancelReason);
+    return orderService.saveOrder(order);
+  }
+
+  private void updatePaymentCancellation(Payment payment, String reason) {
+    payment.updateStatus(PaymentStatus.CANCELED);
+    payment.updateCancelReason(reason);
+    paymentRepository.save(payment);
+
+    PgPaymentLog pgLog = pgPaymentLogRepository.findByPayment(payment);
+    pgLog.cancel();
+    pgPaymentLogRepository.save(pgLog);
+  }
+
+  private void logCancellationFailure(Exception e) {
+    String errorMessage = e.getMessage();
+    String errorType = e.getClass().getSimpleName();
+
+    log.error(
+        "결제 취소 중 오류 발생: errorType-{} : message-{} : exception-{},", errorType, errorMessage, e);
+  }
+}

--- a/src/main/java/com/chone/server/domains/payment/service/PaymentDomainService.java
+++ b/src/main/java/com/chone/server/domains/payment/service/PaymentDomainService.java
@@ -4,6 +4,9 @@ import com.chone.server.commons.exception.ApiBusinessException;
 import com.chone.server.domains.order.domain.Order;
 import com.chone.server.domains.order.domain.OrderStatus;
 import com.chone.server.domains.order.domain.OrderType;
+import com.chone.server.domains.order.exception.OrderExceptionCode;
+import com.chone.server.domains.payment.domain.Payment;
+import com.chone.server.domains.payment.domain.PaymentStatus;
 import com.chone.server.domains.payment.dto.request.CreatePaymentRequest;
 import com.chone.server.domains.payment.dto.response.PaymentDetailResponse;
 import com.chone.server.domains.payment.exception.PaymentExceptionCode;
@@ -19,6 +22,58 @@ public class PaymentDomainService {
     validateOrderStatus(order);
     validatePriceMatch(order, requestDto);
     validatePermissionByRole(order, user);
+  }
+
+  public void validateCustomerViewPermission(
+      PaymentDetailResponse paymentResponse, User currentUser) {
+    if (!(paymentResponse.order().userId().equals(currentUser.getId()))) {
+      throw new ApiBusinessException(PaymentExceptionCode.NOT_CUSTOMER_PAYMENT_HISTORY);
+    }
+  }
+
+  public void validateOwnerViewPermission(PaymentDetailResponse paymentResponse, User currentUser) {
+    if (!(paymentResponse.order().storeUserId().equals(currentUser.getId()))) {
+      throw new ApiBusinessException(PaymentExceptionCode.NOT_OWNER_PAYMENT_HISTORY);
+    }
+  }
+
+  public void validateCancelPaymentRequest(User user, Payment payment) {
+    validateCancellationPermission(user, payment);
+    validateCancellation(payment);
+  }
+
+  private void validateCancellation(Payment payment) {
+    if (payment.getStatus() == PaymentStatus.CANCELED) {
+      throw new ApiBusinessException(PaymentExceptionCode.PAYMENT_ALREADY_CANCELED);
+    }
+    if (payment.getStatus() == PaymentStatus.FAILED) {
+      throw new ApiBusinessException(PaymentExceptionCode.FAILED_PAYMENT);
+    }
+
+    if (!payment.getOrder().isCancelable()) {
+      throw new ApiBusinessException(PaymentExceptionCode.ORDER_NOT_CANCELABLE);
+    }
+  }
+
+  private void validateCancellationPermission(User user, Payment payment) {
+    switch (user.getRole()) {
+      case MANAGER, MASTER -> {
+        return;
+      }
+      case CUSTOMER -> {
+        if (!payment.getOrder().getUser().getId().equals(user.getId())) {
+          throw new ApiBusinessException(OrderExceptionCode.ORDER_CUSTOMER_ACCESS_DENIED);
+        }
+        return;
+      }
+      case OWNER -> {
+        if (!payment.getOrder().getStore().getUser().getId().equals(user.getId())) {
+          throw new ApiBusinessException(OrderExceptionCode.ORDER_STORE_OWNER_ACCESS_DENIED);
+        }
+        return;
+      }
+    }
+    throw new ApiBusinessException(OrderExceptionCode.ORDER_CANCEL_PERMISSION_DENIED);
   }
 
   private void validateOrderStatus(Order order) {
@@ -61,19 +116,6 @@ public class PaymentDomainService {
 
     if (!(order.getStore().getUser().getId().equals(currentUser.getId()))) {
       throw new ApiBusinessException(PaymentExceptionCode.NOT_OWNER_PAYMENT);
-    }
-  }
-
-  public void validateCustomerViewPermission(
-      PaymentDetailResponse paymentResponse, User currentUser) {
-    if (!(paymentResponse.order().userId().equals(currentUser.getId()))) {
-      throw new ApiBusinessException(PaymentExceptionCode.NOT_CUSTOMER_PAYMENT_HISTORY);
-    }
-  }
-
-  public void validateOwnerViewPermission(PaymentDetailResponse paymentResponse, User currentUser) {
-    if (!(paymentResponse.order().storeUserId().equals(currentUser.getId()))) {
-      throw new ApiBusinessException(PaymentExceptionCode.NOT_OWNER_PAYMENT_HISTORY);
     }
   }
 }

--- a/src/main/java/com/chone/server/domains/payment/service/PaymentReadService.java
+++ b/src/main/java/com/chone/server/domains/payment/service/PaymentReadService.java
@@ -1,0 +1,54 @@
+package com.chone.server.domains.payment.service;
+
+import com.chone.server.domains.auth.dto.CustomUserDetails;
+import com.chone.server.domains.order.dto.response.PageResponse;
+import com.chone.server.domains.payment.dto.request.PaymentFilterParams;
+import com.chone.server.domains.payment.dto.response.PaymentDetailResponse;
+import com.chone.server.domains.payment.dto.response.PaymentPageResponse;
+import com.chone.server.domains.payment.repository.PaymentRepository;
+import com.chone.server.domains.user.domain.User;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@Transactional(readOnly = true)
+public class PaymentReadService {
+
+  private final PaymentRepository repository;
+  private final PaymentDomainService domainService;
+
+  public PageResponse<PaymentPageResponse> getPayments(
+      CustomUserDetails principal, PaymentFilterParams filterParams, Pageable pageable) {
+    User user = principal.getUser();
+    return PageResponse.from(findPaymentsByRole(user, filterParams, pageable));
+  }
+
+  public PaymentDetailResponse getPaymentById(CustomUserDetails principal, UUID id) {
+    User user = principal.getUser();
+    PaymentDetailResponse paymentResponse = repository.findPaymentWithDetails(id).toResponse();
+
+    switch (user.getRole()) {
+      case CUSTOMER -> domainService.validateCustomerViewPermission(paymentResponse, user);
+      case OWNER -> domainService.validateOwnerViewPermission(paymentResponse, user);
+      case MANAGER, MASTER -> {}
+    }
+
+    return paymentResponse;
+  }
+
+  private Page<PaymentPageResponse> findPaymentsByRole(
+      User user, PaymentFilterParams filterParams, Pageable pageable) {
+    return switch (user.getRole()) {
+      case CUSTOMER -> repository.findPaymentsByCustomer(user, filterParams, pageable);
+      case OWNER -> repository.findPaymentsByOwner(user, filterParams, pageable);
+      case MANAGER, MASTER -> repository.findPaymentsByAdmin(user, filterParams, pageable);
+    };
+  }
+}

--- a/src/main/java/com/chone/server/domains/user/domain/User.java
+++ b/src/main/java/com/chone/server/domains/user/domain/User.java
@@ -48,7 +48,7 @@ public class User extends BaseEntity {
   private String password;
 
   @NotNull
-  @Column(name = "role", nullable = false, unique = true)
+  @Column(name = "role", nullable = false)
   @Enumerated(EnumType.STRING)
   @Comment("사용자 역할")
   private Role role;


### PR DESCRIPTION
## 📢 개요
1. 결제 취소를 위한 서비스 및 도메인 로직을 구현했습니다.
2. 결제 취소 시 동시성 제어를 했습니다.

### API 스펙
| 항목 | 내용 |
|------|------|
| 메서드 | **`PATCH`** |
| 경로 | `/api/v1/payments/{id}` |
| 권한 | `CUSTOMER`, `OWNER`, `MANAGER`, `MASTER` 역할 접근 가능 |
| 요청 | `CancelPaymentRequest` (검증 어노테이션 적용) |
| 응답 | 200 OK + `CancelPaymentResponse` |

### 역할별 접근 제어
| 역할 | 취소 가능 범위 |
|------|--------------|
| `CUSTOMER` | 자신의 결제만 취소 가능 |
| `OWNER` | 자신의 매장 결제만 취소 가능 |
| `MANAGER`, `MASTER` | 모든 결제 취소 가능 |

<br/>

## 📝 작업 내용
### 변경 사항
#### 1. 결제 취소 서비스 구현
  - `PaymentCancellationService`: 결제 취소 처리
  - `PaymentDomainService`: 결제 취소 관련 도메인 규칙 검증
  - 역할 기반 접근 제어 구현

#### 2. DTO 클래스 구현
  - `CancelPaymentRequest`: 취소 이유를 포함한 요청 클래스 (유효성 검증 적용)
  - `CancelPaymentResponse`: 취소 성공 여부와 결제 상태 정보를 포함한 응답 클래스

#### 3. 동시성 제어
  - 동일 결제에 대한 동시 취소 요청 방지
  - 타임아웃 시 적절한 예외 및 메시지 처리

### 결제 취소 흐름
1. **결제 취소 요청 처리 및 검증**
2. **락을 활용한 취소 처리**
3. **취소 트랜잭션 처리**
4. **주문 취소 처리**
5. **결제 상태 업데이트**
6. **에러 시 로깅**

### 검증 규칙 요약

#### 1. 사용자 권한 기반 검증
   - CUSTOMER: 자신의 결제만 취소 가능
   - OWNER: 자신의 매장 결제만 취소 가능
   - MANAGER/MASTER: 모든 결제 취소 가능

#### 2. 결제 상태 검증
   - 이미 취소된 결제는 재취소 불가
   - 실패한 결제는 취소 불가

#### 3. 주문 상태 검증
   - 취소 가능한 상태의 주문만 결제 취소 가능

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #85

## 📃 PR 유형
- [x] 새로운 기능 추가

## ✅ Check List
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [ ] CI/CD 파이프라인을 통과했습니다.