### PR TITLE
Fix: 배송 정보 없을 시 처리 누락 및 주문 소유권 검증 오류 수정

### DIFF
--- a/src/main/java/com/chone/server/domains/delivery/service/DeliveryDeletionService.java
+++ b/src/main/java/com/chone/server/domains/delivery/service/DeliveryDeletionService.java
@@ -27,6 +27,7 @@ public class DeliveryDeletionService {
       Delivery delivery = repository.findByOrderIdOrNull(deletedOrder.getId());
       if (delivery == null) {
         log.info("주문과 관련된 배송이 없습니다.");
+        return;
       }
       log.info("배송 삭제가 완료되었습니다={}", delivery.getId());
       delivery.delete(event.getDeletedBy());

--- a/src/main/java/com/chone/server/domains/order/facade/OrderFacadeImpl.java
+++ b/src/main/java/com/chone/server/domains/order/facade/OrderFacadeImpl.java
@@ -30,7 +30,7 @@ public class OrderFacadeImpl implements OrderFacade {
   @Override
   public void validateOrderOwnership(Order order, User currentUser) {
     User orderOwnerUser = order.getUser();
-    if (orderOwnerUser.getId().equals(currentUser.getId()))
+    if (!orderOwnerUser.getId().equals(currentUser.getId()))
       throw new ApiBusinessException(OrderExceptionCode.ORDER_CUSTOMER_ACCESS_DENIED);
   }
 

--- a/src/main/java/com/chone/server/domains/order/service/OrderCreationService.java
+++ b/src/main/java/com/chone/server/domains/order/service/OrderCreationService.java
@@ -57,9 +57,6 @@ public class OrderCreationService {
 
     Order savedOrder = repository.save(order);
 
-    // TODO: 1. 결제
-    //       2. 배달
-
     return CreateOrderResponse.from(savedOrder);
   }
 }


### PR DESCRIPTION
## 📢 개요

QA 도중 발견된 두 가지 오류를 수정했습니다.  
1. 배송 정보가 없을 경우 `return`이 누락되어 불필요한 코드 실행이 발생하는 문제 수정  
2. `validateOrderOwnership`에서 소유자 확인 로직이 잘못되어 예외가 올바르게 던져지지 않는 문제 수정  

## 📝 작업 내용

### 변경 사항

- `DeliveryDeletionService.handleOrderDeletion`에서 배송 정보가 없을 경우 `return`을 추가하여 불필요한 코드 실행 방지  
- `validateOrderOwnership`에서 `!` 연산자 추가하여 소유자가 아닌 경우 예외가 발생하도록 수정  

### 변경 이유

- 배송 정보가 없는 경우에도 이후 코드가 실행되는 문제로 인해 불필요한 오류 로그가 발생할 수 있음  
- 주문 소유자 검증 로직이 반대로 동작하여, 소유자가 예외를 던지는 문제가 발생  

### 추가 설명

- `DeliveryDeletionService`의 기존 로직에서 `delivery == null`일 때 바로 `return`하지 않으면 `delivery.delete(event.getDeletedBy());` 실행 시 NPE 발생 가능  
- `validateOrderOwnership`에서 `!` 연산자가 빠져 있어 소유자가 예외를 던지는 문제가 있었음  

## 💬 리뷰 요구사항

- 기존 로직에서 문제가 되었던 부분이 올바르게 수정되었는지 확인 부탁드립니다.  
- 추가적으로 개선할 부분이 있다면 피드백 부탁드립니다.  

#### #️⃣ 연관된 이슈

closed #<이슈 번호>

## 📃 PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 버그 수정  

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)  
- [ ] CI/CD 파이프라인을 통과했습니다.  